### PR TITLE
Monitor dates

### DIFF
--- a/PAS/Monitoring/Collector/ablapps/Business/Report.cls
+++ b/PAS/Monitoring/Collector/ablapps/Business/Report.cls
@@ -39,11 +39,13 @@ class Business.Report use-widget-pool:
 
     define private temp-table ttDate
         field sampleDate as date
+        index idxDate sampleDate
         .
 
     define private temp-table ttGroup
         field timestamp   as datetime-tz
         field sampleGroup as character
+        index idxTime as primary timestamp
         .
 
     method private character FormatMsTime ( input piValue as int64 ):
@@ -102,44 +104,47 @@ class Business.Report use-widget-pool:
         define variable iDateCount as integer no-undo.
         define variable iGrpCount  as integer no-undo.
 
+        define buffer bAgentSample for AgentSample.
+        define buffer bServerInfo for ServerInfo.
+
         assign appServer = temp-table appServer:handle.
 
         empty temp-table appServer.
 
-        for each ServerInfo no-lock
-              by ServerInfo.ApplicationName
-              by ServerInfo.ServerName:
+        for each bServerInfo no-lock
+              by bServerInfo.ApplicationName
+              by bServerInfo.ServerName:
             create appServer.
             assign
-                appServer.applicationName = ServerInfo.ApplicationName
-                appServer.serverName      = ServerInfo.ServerName
-                appServer.appServerUUID   = ServerInfo.ServerUUID
+                appServer.applicationName = bServerInfo.ApplicationName
+                appServer.serverName      = bServerInfo.ServerName
+                appServer.appServerUUID   = bServerInfo.ServerUUID
                 .
 
             /* Find all sample groups for this agent. */
             empty temp-table ttGroup.
-            for each AgentSample no-lock
-               where AgentSample.ServerUUID eq ServerInfo.ServerUUID
-               break by AgentSample.SampleGroup:
-                if first-of(AgentSample.SampleGroup) then do:
+            for each bAgentSample no-lock
+               where bAgentSample.ServerUUID eq bServerInfo.ServerUUID
+               break by bAgentSample.SampleGroup:
+                if first-of(bAgentSample.SampleGroup) then do:
                     create ttGroup.
                     assign
-                        ttGroup.sampleGroup = AgentSample.SampleGroup
-                        ttGroup.timestamp   = AgentSample.Timestamp
+                        ttGroup.sampleGroup = bAgentSample.SampleGroup
+                        ttGroup.timestamp   = bAgentSample.Timestamp
                         .
                 end.
-            end. /* for each ServerInfo */
+            end. /* for each bServerInfo */
 
             /* Find all sample dates for this agent. */
             empty temp-table ttDate.
-            for each AgentSample no-lock
-               where AgentSample.ServerUUID eq ServerInfo.ServerUUID
-               break by AgentSample.Timestamp:
-                if not can-find(first ttDate where ttDate.sampleDate eq date(AgentSample.Timestamp)) then do:
+            for each bAgentSample no-lock
+               where bAgentSample.ServerUUID eq bServerInfo.ServerUUID
+               break by bAgentSample.Timestamp:
+                if not can-find(first ttDate where ttDate.sampleDate eq date(bAgentSample.Timestamp)) then do:
                     create ttDate.
-                    assign ttDate.sampleDate = date(AgentSample.Timestamp).
+                    assign ttDate.sampleDate = date(bAgentSample.Timestamp).
                 end.
-            end. /* for each ServerInfo */
+            end. /* for each bServerInfo */
 
             /* Add only the last 10 group names in reverse chronological order. */
             assign iGrpCount = 1.
@@ -160,7 +165,7 @@ class Business.Report use-widget-pool:
             end. /* for each iDateCount */
 
             release appServer no-error.
-        end. /* for each ServerInfo*/
+        end. /* for each bServerInfo*/
     end method. /* GetServerList */
 
 
@@ -183,6 +188,10 @@ class Business.Report use-widget-pool:
         define variable iSort       as int64    no-undo initial 1.
         define variable dLastSample as datetime no-undo.
 
+        define buffer bRequestInfo   for RequestInfo.
+        define buffer bSessionInfo   for SessionInfo.
+        define buffer bSessionSample for SessionSample.
+
         assign agentSession = temp-table agentSession:handle.
 
         if sampleGroup eq "All" then assign sampleGroup = "". /* Normalize the option for all groups. */
@@ -190,22 +199,22 @@ class Business.Report use-widget-pool:
         empty temp-table agentSession.
 
         /* Return a list of ALL agents and their sessions for the given application/server. */
-        for each SessionInfo no-lock
-           where SessionInfo.ServerUUID eq serverUUID
-              by SessionInfo.Started
-              by SessionInfo.AgentPID
-              by SessionInfo.SessionID:
+        for each bSessionInfo no-lock
+           where bSessionInfo.ServerUUID eq serverUUID
+              by bSessionInfo.Started
+              by bSessionInfo.AgentPID
+              by bSessionInfo.SessionID:
 
             /* Create record for each agent-session. */
             create agentSession.
             assign
-                agentSession.sessionSort      = iSort
-                agentSession.agentPID         = SessionInfo.AgentPID
-                agentSession.agentDisplay     = string(SessionInfo.AgentPID)
-                agentSession.sessionID        = SessionInfo.SessionID
-                agentSession.startedDate      = date(SessionInfo.Started) /* Extract only the date! */
-                agentSession.startedTime      = entry(2, string(SessionInfo.Started), " ") when num-entries(string(SessionInfo.Started), " ") ge 2
-                agentSession.agentSessionUUID = SessionInfo.SessionUUID
+                agentSession.sessionSort      = iSort /* Keeps data sorted by the original query (time, agent, session). */
+                agentSession.agentPID         = bSessionInfo.AgentPID
+                agentSession.agentDisplay     = string(bSessionInfo.AgentPID)
+                agentSession.sessionID        = bSessionInfo.SessionID
+                agentSession.startedDate      = date(bSessionInfo.Started) /* Extract only the date! */
+                agentSession.startedTime      = entry(2, string(bSessionInfo.Started), " ") when num-entries(string(bSessionInfo.Started), " ") ge 2
+                agentSession.agentSessionUUID = bSessionInfo.SessionUUID
                 .
 
             assign
@@ -225,67 +234,75 @@ class Business.Report use-widget-pool:
 
             /* Get the timestamp of the very first request for this agent-session. */
             firstreqblk:
-            for each SessionSample no-lock
-               where SessionSample.SessionUUID eq SessionInfo.SessionUUID
-                 and (sampleGroup eq "" or SessionSample.SampleGroup eq sampleGroup)
-                  by SessionSample.Timestamp:
-                for first RequestInfo no-lock
-                    where RequestInfo.SampleUUID eq SessionSample.SampleUUID
-                      and RequestInfo.StartTime ne ?
-                       by RequestInfo.StartTime:
-                    assign agentSession.requestStart = RequestInfo.StartTime.
-                end. /* for first RequestInfo */
+            for each bSessionSample no-lock
+               where bSessionSample.SessionUUID eq bSessionInfo.SessionUUID                 
+                  by bSessionSample.Timestamp:
+                /* Move to the next if a sample group was named but this record is not in that group. */ 
+                if sampleGroup gt "" and bSessionSample.SampleGroup ne sampleGroup then next firstreqblk.
+
+                for first bRequestInfo no-lock
+                    where bRequestInfo.SampleUUID eq bSessionSample.SampleUUID
+                      and bRequestInfo.StartTime ne ?
+                       by bRequestInfo.StartTime:
+                    assign agentSession.requestStart = bRequestInfo.StartTime.
+                end. /* for first bRequestInfo */
 
                 if agentSession.requestStart ne ? then leave firstreqblk.
-            end. /* for each SessionSample */
+            end. /* for each bSessionSample */
 
             /* Get the timestamp of the very last request for this agent-session. */
-            for each SessionSample no-lock
-               where SessionSample.SessionUUID eq SessionInfo.SessionUUID
-                 and (sampleGroup eq "" or SessionSample.SampleGroup eq sampleGroup)
-                  by SessionSample.Timestamp:
-                for last RequestInfo no-lock
-                   where RequestInfo.SampleUUID eq SessionSample.SampleUUID
-                     and RequestInfo.EndTime ne ?
-                      by RequestInfo.EndTime:
-                    assign agentSession.requestLast = RequestInfo.EndTime.
-                end. /* for last RequestInfo */
-            end. /* for each SessionSample */
+            lastreqblk:
+            for each bSessionSample no-lock
+               where bSessionSample.SessionUUID eq bSessionInfo.SessionUUID
+                  by bSessionSample.Timestamp:
+                /* Move to the next if a sample group was named but this record is not in that group. */ 
+                if sampleGroup gt "" and bSessionSample.SampleGroup ne sampleGroup then next lastreqblk.
+
+                for last bRequestInfo no-lock
+                   where bRequestInfo.SampleUUID eq bSessionSample.SampleUUID
+                     and bRequestInfo.EndTime ne ?
+                      by bRequestInfo.EndTime:
+                    assign agentSession.requestLast = bRequestInfo.EndTime.
+                end. /* for last bRequestInfo */
+            end. /* for each bSessionSample */
 
             /* If request did not have a known end time, assume last request was recieved as of now. */
             if agentSession.requestLast eq ? then
                 assign agentSession.requestLast = now.
 
             /* Get a count of total requests for this agent-session. */
-            for each RequestInfo no-lock
-               where RequestInfo.ServerUUID eq SessionInfo.ServerUUID
-                 and RequestInfo.SessionUUID eq SessionInfo.SessionUUID:
+            for each bRequestInfo no-lock
+               where bRequestInfo.ServerUUID eq bSessionInfo.ServerUUID
+                 and bRequestInfo.SessionUUID eq bSessionInfo.SessionUUID:
                 assign
                     agentSession.requestCount = agentSession.requestCount + 1
-                    iReqTime                  = iReqTime + RequestInfo.Elapsed
+                    iReqTime                  = iReqTime + bRequestInfo.Elapsed
                     .
             end. /* for each agentSession */
 
             /* Cycle through samples for each session of agent. */
-            for each SessionSample no-lock
-               where SessionSample.SessionUUID eq SessionInfo.SessionUUID
-                 and (sampleGroup eq "" or SessionSample.SampleGroup eq sampleGroup)
-                  by SessionSample.Timestamp:
+            sampleblk:
+            for each bSessionSample no-lock
+               where bSessionSample.SessionUUID eq bSessionInfo.SessionUUID
+                  by bSessionSample.Timestamp:
+                /* Move to the next if a sample group was named but this record is not in that group. */ 
+                if sampleGroup gt "" and bSessionSample.SampleGroup ne sampleGroup then next sampleblk.
+
                 /* Count the total samples reported for this session. */
                 assign iSmplCount = iSmplCount + 1.
 
                 /* Count objects but only for samples with a non-zero value. */
-                if SessionSample.ObjectCount gt 0 then
+                if bSessionSample.ObjectCount gt 0 then
                     assign
-                        iObjCount  = iObjCount + SessionSample.ObjectCount
-                        iObjMax    = max(iObjMax, SessionSample.ObjectCount)
+                        iObjCount  = iObjCount + bSessionSample.ObjectCount
+                        iObjMax    = max(iObjMax, bSessionSample.ObjectCount)
                         iObjSample = iObjSample + 1
                         .
 
                 /* Calculate memory metrics but only for samples with a non-zero value. */
-                if SessionSample.MemoryBytes gt 0 then do:
+                if bSessionSample.MemoryBytes gt 0 then do:
                     assign
-                        fMemBytes  = round(SessionSample.MemoryBytes / 1024, 1)
+                        fMemBytes  = round(bSessionSample.MemoryBytes / 1024, 1)
                         fMemMax    = max(fMemMax, fMemBytes)
                         fMemMin    = min(fMemMin, fMemBytes)
                         fMemTotal  = fMemTotal + fMemBytes
@@ -295,8 +312,8 @@ class Business.Report use-widget-pool:
                 end. /* Non-Zero Memory */
 
                 /* Get the last sample time when this session appears. */
-                assign dLastSample = SessionSample.Timestamp.
-            end. /* for each SessionInfo */
+                assign dLastSample = bSessionSample.Timestamp.
+            end. /* for each bSessionInfo */
 
             assign /* Assign min/max/avg values for the session. */
                 agentSession.memoryMin      = fMemMin
@@ -317,11 +334,11 @@ class Business.Report use-widget-pool:
                 agentSession.requestDuration = interval(agentSession.requestLast, agentSession.requestStart, "seconds")
                 agentSession.requestPerSec   = if agentSession.requestDuration gt 0 then (agentSession.requestCount / agentSession.requestDuration) else 0
                 /* Calculate the elapsed runtime by getting the difference of a last sample time and the start of the session. */
-                agentSession.elapsedRuntime  = FormatMsTime(interval(agentSession.lastSample, SessionInfo.Started, "milliseconds"))
+                agentSession.elapsedRuntime  = FormatMsTime(interval(agentSession.lastSample, bSessionInfo.Started, "milliseconds"))
                 .
 
             release agentSession no-error.
-        end. /* for each ServerInfo, SessionInfo */
+        end. /* for each bSessionInfo */
 
         /* Get some totals for the entire application. */
         this-object:CalculateRequestPercentages().
@@ -336,7 +353,8 @@ class Business.Report use-widget-pool:
                                          input  sampleDate   as date,
                                          input  sampleGroup  as character,
                                          output agentMetrics as handle ):
-        define variable lSuccess    as logical  no-undo.
+        define variable lSuccess    as logical  no-undo initial false.
+        define variable lHasSession as logical  no-undo initial false.
         define variable dLastSample as datetime no-undo initial ?.
         define variable fMemPeak    as decimal  no-undo initial 0. /* Tracked across all sessions for this agent. */
         define variable fMemBytes   as decimal  no-undo initial 0.
@@ -353,9 +371,15 @@ class Business.Report use-widget-pool:
         define variable iReqCount   as int64    no-undo initial 0.
         define variable iSort       as int64    no-undo initial 1.
 
+        define buffer bAgentSample   for AgentSample.
+        define buffer bRequestInfo   for RequestInfo.
+        define buffer bSessionInfo   for SessionInfo.
+        define buffer bSessionSample for SessionSample.
+
         assign agentMetrics = dataset agentMetrics:handle.
 
         if sampleGroup eq "All" then assign sampleGroup = "". /* Normalize the option for all groups. */
+        if sessionID gt 0 then lHasSession = true. /* Denotes a specific session was given. */
 
         empty temp-table instanceAgent.
         empty temp-table agentStat.
@@ -364,13 +388,17 @@ class Business.Report use-widget-pool:
         empty temp-table sessionStat.
 
         /* Get the agent stats for this server and sample group. */
-        for each AgentSample no-lock
-           where AgentSample.ServerUUID eq serverUUID
-             and AgentSample.AgentPID eq agentPID
-             and (sampleGroup eq "" or AgentSample.SampleGroup eq sampleGroup)
-           break by AgentSample.AgentPID
-                 by AgentSample.Timestamp:
-            if first-of(AgentSample.AgentPID) then do:
+        sampleblk:
+        for each bAgentSample no-lock
+           where bAgentSample.ServerUUID eq serverUUID
+             and bAgentSample.AgentPID eq agentPID
+           break by bAgentSample.AgentPID
+                 by bAgentSample.Timestamp:
+            /* Move to the next if a sample group was named but this record is not in that group. */ 
+            if sampleGroup gt "" and bAgentSample.SampleGroup ne sampleGroup then next sampleblk.
+
+            /* Always create a record for an agent of this server.*/
+            if first-of(bAgentSample.AgentPID) then do:
                 create instanceAgent.
                 assign
                     instanceAgent.appServerUUID = serverUUID
@@ -380,43 +408,49 @@ class Business.Report use-widget-pool:
             end.
 
             /* If a sample date is provided but date does not match, skip the sample.*/
-            if sampleDate ne ? and date(AgentSample.Timestamp) ne sampleDate then next.
+            if sampleDate ne ? and date(bAgentSample.Timestamp) ne sampleDate then next sampleblk.
 
             create agentStat.
             assign
                 agentStat.agentPID       = agentPID
-                agentStat.agentStarted   = AgentSample.AgentStarted
-                agentStat.dateSample     = AgentSample.Timestamp
-                agentStat.busySessions   = AgentSample.BusySessions
+                agentStat.agentStarted   = bAgentSample.AgentStarted
+                agentStat.dateSample     = bAgentSample.Timestamp
+                agentStat.busySessions   = bAgentSample.BusySessions
                 agentStat.requestCount   = 0
                 .
             release agentStat no-error.
 
             /* Remember the current overhead memory value for this agent. */
-            if AgentSample.OverheadMemory ne ? and AgentSample.OverheadMemory gt 0 then
-                assign fAgentMem = round(AgentSample.OverheadMemory / 1024, 1).
-        end. /* AgentSample */
+            if bAgentSample.OverheadMemory ne ? and bAgentSample.OverheadMemory gt 0 then
+                assign fAgentMem = round(bAgentSample.OverheadMemory / 1024, 1).
+        end. /* bAgentSample */
 
         /* Return a specific agent-session's memory/object data over time for each session sample. */
-        for each SessionInfo no-lock
-           where SessionInfo.ServerUUID eq serverUUID
-             and (agentPID eq 0 or SessionInfo.AgentPID eq agentPID)
-             and (sessionID eq 0 or SessionInfo.SessionID eq sessionID)
-              by SessionInfo.Started
-              by SessionInfo.AgentPID
-              by SessionInfo.SessionID:
+        infoblk:
+        for each bSessionInfo no-lock
+           where bSessionInfo.ServerUUID eq serverUUID
+              by bSessionInfo.Started
+              by bSessionInfo.AgentPID
+              by bSessionInfo.SessionID:
+            /* Move to the next if an agentPID was given but this sample is not for that Agent. */ 
+            if agentPID gt 0 and bSessionInfo.AgentPID ne agentPID then next infoblk.
 
-            /* Create record for each agent-session. */
-            create agentSession.
-            assign
-                agentSession.sessionSort      = iSort
-                agentSession.agentPID         = SessionInfo.AgentPID
-                agentSession.agentDisplay     = string(SessionInfo.AgentPID)
-                agentSession.sessionID        = SessionInfo.SessionID
-                agentSession.startedDate      = date(SessionInfo.Started) /* Extract only the date! */
-                agentSession.startedTime      = entry(2, string(SessionInfo.Started), " ") when num-entries(string(SessionInfo.Started), " ") ge 2
-                agentSession.agentSessionUUID = SessionInfo.SessionUUID
-                .
+            /* Move to the next if a sessionID was given but this sample is not for that Session. */ 
+            if lHasSession and bSessionInfo.SessionID ne sessionID then next infoblk.
+
+            if lHasSession then do:
+                /* Create record for each agent-session. */
+                create agentSession.
+                assign
+                    agentSession.sessionSort      = iSort
+                    agentSession.agentPID         = bSessionInfo.AgentPID
+                    agentSession.agentDisplay     = string(bSessionInfo.AgentPID)
+                    agentSession.sessionID        = bSessionInfo.SessionID
+                    agentSession.startedDate      = date(bSessionInfo.Started) /* Extract only the date! */
+                    agentSession.startedTime      = entry(2, string(bSessionInfo.Started), " ") when num-entries(string(bSessionInfo.Started), " ") ge 2
+                    agentSession.agentSessionUUID = bSessionInfo.SessionUUID
+                    .
+            end. /* lHasSession */
 
             assign
                 fMemBytes  = 0
@@ -435,63 +469,73 @@ class Business.Report use-widget-pool:
 
             /* Get the timestamp of the very first request for this agent-session. */
             firstreqblk:
-            for each SessionSample no-lock
-               where SessionSample.SessionUUID eq SessionInfo.SessionUUID
-                 and (sampleGroup eq "" or SessionSample.SampleGroup eq sampleGroup)
-                  by SessionSample.Timestamp:
-                for first RequestInfo no-lock
-                    where RequestInfo.SampleUUID eq SessionSample.SampleUUID
-                      and RequestInfo.StartTime ne ?
-                       by RequestInfo.StartTime:
+            for each bSessionSample no-lock
+               where bSessionSample.SessionUUID eq bSessionInfo.SessionUUID
+                  by bSessionSample.Timestamp:
+                /* Move to the next if a sample group was named but this record is not in that group. */ 
+                if sampleGroup gt "" and bSessionSample.SampleGroup ne sampleGroup then next firstreqblk.
+
+                for first bRequestInfo no-lock
+                    where bRequestInfo.SampleUUID eq bSessionSample.SampleUUID
+                      and bRequestInfo.StartTime ne ?
+                       by bRequestInfo.StartTime:
                     assign
-                        agentSession.requestStart = RequestInfo.StartTime
-                        dLastSample               = RequestInfo.StartTime
+                        agentSession.requestStart = bRequestInfo.StartTime when available(agentSession)
+                        dLastSample               = bRequestInfo.StartTime
                         .
-                end. /* for first RequestInfo */
+                end. /* for first bRequestInfo */
 
-                if agentSession.requestStart ne ? then leave firstreqblk.
-            end. /* for each SessionSample */
+                if available(agentSession) and agentSession.requestStart ne ? then leave firstreqblk.
+            end. /* for each bSessionSample */
 
-            /* Get the timestamp of the very last request for this agent-session. */
-            for each SessionSample no-lock
-               where SessionSample.SessionUUID eq SessionInfo.SessionUUID
-                 and (sampleGroup eq "" or SessionSample.SampleGroup eq sampleGroup)
-                  by SessionSample.Timestamp:
-                for last RequestInfo no-lock
-                   where RequestInfo.SampleUUID eq SessionSample.SampleUUID
-                     and RequestInfo.EndTime ne ?
-                      by RequestInfo.EndTime:
-                    assign agentSession.requestLast = RequestInfo.EndTime.
-                end. /* for last RequestInfo */
-            end. /* for each SessionSample */
+            if lHasSession then do:
+                /* Get the timestamp of the very last request for this agent-session. */
+                sampleblk:
+                for each bSessionSample no-lock
+                   where bSessionSample.SessionUUID eq bSessionInfo.SessionUUID
+                      by bSessionSample.Timestamp:
+                    /* Move to the next if a sample group was named but this record is not in that group. */ 
+                    if sampleGroup gt "" and bSessionSample.SampleGroup ne sampleGroup then next sampleblk.
+    
+                    for last bRequestInfo no-lock
+                       where bRequestInfo.SampleUUID eq bSessionSample.SampleUUID
+                         and bRequestInfo.EndTime ne ?
+                          by bRequestInfo.EndTime:
+                        assign agentSession.requestLast = bRequestInfo.EndTime.
+                    end. /* for last bRequestInfo */
+                end. /* for each bSessionSample */
 
-            /* If request did not have a known end time, assume last request was recieved as of now. */
-            if agentSession.requestLast eq ? then
-                assign agentSession.requestLast = now.
+                /* If request did not have a known end time, assume last request was recieved as of now. */
+                if agentSession.requestLast eq ? then
+                    assign agentSession.requestLast = now.
+            end. /* lHasSession */
 
             /* Get stats for the session as based on the available samples. */
-            for each SessionSample no-lock
-               where SessionSample.SessionUUID eq SessionInfo.SessionUUID
-                 and (sampleGroup eq "" or SessionSample.SampleGroup eq sampleGroup)
-                  by SessionSample.Timestamp:
+            sampleblk:
+            for each bSessionSample no-lock
+               where bSessionSample.SessionUUID eq bSessionInfo.SessionUUID
+                  by bSessionSample.Timestamp:
+                /* Move to the next if a sample group was named but this record is not in that group. */ 
+                if sampleGroup gt "" and bSessionSample.SampleGroup ne sampleGroup then next sampleblk.
+
                 /* If a sample date is provided but date does not match, skip the sample.*/
-                if sampleDate ne ? and date(SessionSample.Timestamp) ne sampleDate then next.
+                if sampleDate ne ? and date(bSessionSample.Timestamp) ne sampleDate then next sampleblk.
 
                 /* Count the total samples reported for this session. */
                 assign iSmplCount = iSmplCount + 1.
 
                 /* Count objects but only for samples with a non-zero value. */
-                if SessionSample.ObjectCount gt 0 then
+                if bSessionSample.ObjectCount gt 0 then
                     assign
-                        iObjCount  = iObjCount + SessionSample.ObjectCount
-                        iObjMax    = max(iObjMax, SessionSample.ObjectCount)
+                        iObjCount  = iObjCount + bSessionSample.ObjectCount
+                        iObjMax    = max(iObjMax, bSessionSample.ObjectCount)
                         iObjSample = iObjSample + 1
                         .
 
                 /* Calculate memory metrics but only for samples with a non-zero value. */
-                if SessionSample.MemoryBytes gt 0 then do:
+                if bSessionSample.MemoryBytes gt 0 then do:
                     assign
-                        fMemBytes  = round(SessionSample.MemoryBytes / 1024, 1)
+                        fMemBytes  = round(bSessionSample.MemoryBytes / 1024, 1)
                         fMemMax    = max(fMemMax, fMemBytes)
                         fMemMin    = min(fMemMin, fMemBytes)
                         fMemTotal  = fMemTotal + fMemBytes
@@ -502,9 +546,9 @@ class Business.Report use-widget-pool:
 
                 create sessionActivity.
                 assign
-                    sessionActivity.agentPID     = SessionInfo.AgentPID
-                    sessionActivity.sessionID    = SessionInfo.SessionID
-                    sessionActivity.dateSample   = SessionSample.Timestamp
+                    sessionActivity.agentPID     = bSessionInfo.AgentPID
+                    sessionActivity.sessionID    = bSessionInfo.SessionID
+                    sessionActivity.dateSample   = bSessionSample.Timestamp
                     sessionActivity.memoryBytes  = fMemBytes
                     sessionActivity.requestCount = 0
                     sessionActivity.avgElapsed   = 0
@@ -513,17 +557,17 @@ class Business.Report use-widget-pool:
 
                 create sessionStat.
                 assign
-                    sessionStat.agentSessionUUID  = SessionSample.SessionUUID
-                    sessionStat.sessionSampleUUID = SessionSample.SampleUUID
-                    sessionStat.dateSample        = SessionSample.Timestamp
+                    sessionStat.agentSessionUUID  = bSessionSample.SessionUUID
+                    sessionStat.SessionSampleUUID = bSessionSample.SampleUUID
+                    sessionStat.dateSample        = bSessionSample.Timestamp
                     sessionStat.memoryBytes       = fMemBytes
-                    sessionStat.objectCount       = SessionSample.ObjectCount
+                    sessionStat.objectCount       = bSessionSample.ObjectCount
                     .
 
                 /* Keep a cumulative count of requests by agent/timestamp. */
                 for first agentStat exclusive-lock
-                    where agentStat.agentPID eq SessionInfo.AgentPID
-                      and agentStat.dateSample eq SessionSample.Timestamp:
+                    where agentStat.agentPID eq bSessionInfo.AgentPID
+                      and agentStat.dateSample eq bSessionSample.Timestamp:
                     /* Keep tracking the cumulative MAXIMUM calculated memory value. */
                     assign fMemPeak = max(agentStat.memoryBytes + fMemMax, fMemPeak).
 
@@ -536,23 +580,23 @@ class Business.Report use-widget-pool:
                 end. /* for first */
 
                 /* If not the first sample, count the requests serviced by this session since the last sample. */
-                for each RequestInfo no-lock
-                   where RequestInfo.SampleUUID eq SessionSample.SampleUUID
-                     and RequestInfo.StartTime ge dLastSample
-                     and RequestInfo.StartTime lt SessionSample.Timestamp
-                     and RequestInfo.EndTime ne ?:
+                for each bRequestInfo no-lock
+                   where bRequestInfo.SampleUUID eq bSessionSample.SampleUUID
+                     and bRequestInfo.StartTime ge dLastSample
+                     and bRequestInfo.StartTime lt bSessionSample.Timestamp
+                     and bRequestInfo.EndTime ne ?:
                     assign
-                        agentSession.requestCount    = agentSession.requestCount + 1
+                        agentSession.requestCount    = agentSession.requestCount + 1 when available(agentSession)
                         sessionActivity.requestCount = sessionActivity.requestCount + 1
-                        sessionActivity.avgElapsed   = sessionActivity.avgElapsed + RequestInfo.Elapsed
-                        sessionActivity.maxElapsed   = max(sessionActivity.maxElapsed, RequestInfo.Elapsed)
-                        iReqTime                     = iReqTime + RequestInfo.Elapsed
+                        sessionActivity.avgElapsed   = sessionActivity.avgElapsed + bRequestInfo.Elapsed
+                        sessionActivity.maxElapsed   = max(sessionActivity.maxElapsed, bRequestInfo.Elapsed)
+                        iReqTime                     = iReqTime + bRequestInfo.Elapsed
                         .
 
                     /* Keep a cumulative count of requests by agent/timestamp. */
                     for first agentStat exclusive-lock
-                        where agentStat.agentPID eq SessionInfo.AgentPID
-                          and agentStat.dateSample eq SessionSample.Timestamp:
+                        where agentStat.agentPID eq bSessionInfo.AgentPID
+                          and agentStat.dateSample eq bSessionSample.Timestamp:
                         assign agentStat.requestCount = agentStat.requestCount + 1.
                     end. /* for first */
                 end. /* For each request since last Sample. */
@@ -562,35 +606,37 @@ class Business.Report use-widget-pool:
 
                 /* Mark this as sample as the last timestamp for comparison in the next round. */
                 assign
-                    dLastSample = SessionSample.Timestamp
-                    iReqCount   = agentSession.requestCount
+                    dLastSample = bSessionSample.Timestamp
+                    iReqCount   = agentSession.requestCount when available(agentSession)
                     .
 
                 release sessionActivity no-error.
                 release sessionStat no-error.
-            end. /* for each SessionInfo */
+            end. /* for each bSessionSample */
 
-            assign /* Assign min/max/avg values for the session. */
-                agentSession.memoryMin      = fMemMin
-                agentSession.memoryMax      = fMemMax
-                agentSession.memoryAvg      = round((fMemTotal / iMemSample), 2) when iMemSample gt 0
-                agentSession.memoryDelta    = round((fMemMax - fMemMin), 2)
-                agentSession.memorySamples  = iMemSample
-                agentSession.objectMax      = iObjMax
-                agentSession.objectTotal    = iObjCount
-                agentSession.objectAvg      = round((iObjCount / iObjSample), 1) when iObjSample gt 0
-                agentSession.objectSamples  = iObjSample
-                agentSession.totalSamples   = iSmplCount
-                agentSession.requestTimeAvg = round((iReqTime / iReqCount), 1) when iReqCount gt 0
-                .
+            if lHasSession then do:
+                assign /* Assign min/max/avg values for the session. */
+                    agentSession.memoryMin      = fMemMin
+                    agentSession.memoryMax      = fMemMax
+                    agentSession.memoryAvg      = round((fMemTotal / iMemSample), 2) when iMemSample gt 0
+                    agentSession.memoryDelta    = round((fMemMax - fMemMin), 2)
+                    agentSession.memorySamples  = iMemSample
+                    agentSession.objectMax      = iObjMax
+                    agentSession.objectTotal    = iObjCount
+                    agentSession.objectAvg      = round((iObjCount / iObjSample), 1) when iObjSample gt 0
+                    agentSession.objectSamples  = iObjSample
+                    agentSession.totalSamples   = iSmplCount
+                    agentSession.requestTimeAvg = round((iReqTime / iReqCount), 1) when iReqCount gt 0
+                    .
 
-            assign
-                agentSession.requestDuration = interval(agentSession.requestLast, agentSession.requestStart, "seconds")
-                agentSession.requestPerSec   = if agentSession.requestDuration gt 0 then (agentSession.requestCount / agentSession.requestDuration) else 0
-                .
+                assign
+                    agentSession.requestDuration = interval(agentSession.requestLast, agentSession.requestStart, "seconds")
+                    agentSession.requestPerSec   = if agentSession.requestDuration gt 0 then (agentSession.requestCount / agentSession.requestDuration) else 0
+                    .
 
-            release agentSession no-error.
-        end. /* for each SessionInfo */
+                release agentSession no-error.
+            end. /* lHasSession */
+        end. /* for each bSessionInfo */
 
         /* Get some totals for the entire application. */
         this-object:CalculateRequestPercentages().
@@ -604,39 +650,42 @@ class Business.Report use-widget-pool:
                                        input  sampleGroup  as character,
                                        input  sampleDate   as datetime,
                                        output sampleObject as handle ):
+        define buffer bABLObject     for ABLObject.
+        define buffer bSessionSample for SessionSample.
+
         assign sampleObject = temp-table sampleObject:handle.
 
         if sampleGroup eq "All" then assign sampleGroup = "". /* Normalize the option for all groups. */
 
         /* Locate the first session sample with the given object count, nearest the given date. */
-        find first SessionSample no-lock
-             where SessionSample.SampleUUID eq sampleUUID
-               and (sampleGroup eq "" or SessionSample.SampleGroup eq sampleGroup)
-               and SessionSample.ObjectCount eq objectCount no-error.
-        if not available(SessionSample) then
-            find first SessionSample no-lock
-                 where (sampleGroup eq "" or SessionSample.SampleGroup eq sampleGroup)
-                   and SessionSample.ObjectCount eq objectCount
-                   and SessionSample.Timestamp gt sampleDate no-error.
+        find first bSessionSample no-lock
+             where bSessionSample.SampleUUID eq sampleUUID
+               and (sampleGroup eq "" or bSessionSample.SampleGroup eq sampleGroup)
+               and bSessionSample.ObjectCount eq objectCount no-error.
+        if not available(bSessionSample) then
+            find first bSessionSample no-lock
+                 where (sampleGroup eq "" or bSessionSample.SampleGroup eq sampleGroup)
+                   and bSessionSample.ObjectCount eq objectCount
+                   and bSessionSample.Timestamp gt sampleDate no-error.
 
         empty temp-table sampleObject.
 
         /* Return a list of objects for a given sample interval. */
-        if available(SessionSample) then
-            for each ABLObject no-lock
-               where ABLObject.SampleUUID eq SessionSample.SampleUUID:
+        if available(bSessionSample) then
+            for each bABLObject no-lock
+               where bABLObject.SampleUUID eq bSessionSample.SampleUUID:
                 create sampleObject.
                 assign
-                    sampleObject.handleId  = ABLObject.HandleId
-                    sampleObject.source    = ABLObject.Source
-                    sampleObject.line      = ABLObject.Line
-                    sampleObject.origReqId = ABLObject.RequestNum
-                    sampleObject.name      = ABLObject.Name
-                    sampleObject.objType   = ABLObject.ObjType
-                    sampleObject.objSize   = ABLObject.Size
+                    sampleObject.handleId  = bABLObject.HandleId
+                    sampleObject.source    = bABLObject.Source
+                    sampleObject.line      = bABLObject.Line
+                    sampleObject.origReqId = bABLObject.RequestNum
+                    sampleObject.name      = bABLObject.Name
+                    sampleObject.objType   = bABLObject.ObjType
+                    sampleObject.objSize   = bABLObject.Size
                     .
                 release sampleObject no-error.
-            end. /* for each ABLObject */
+            end. /* for each bABLObject */
     end method. /* GetABLObjects */
 
 
@@ -646,6 +695,9 @@ class Business.Report use-widget-pool:
                                      input  sampleDate      as date,
                                      input  sampleGroup     as character,
                                      output ablRequestStack as handle ):
+        define buffer bRequestInfo   for RequestInfo.
+        define buffer bSessionSample for SessionSample.
+
         assign ablRequestStack = dataset ablRequestStack:handle.
 
         empty temp-table ablRequest.
@@ -654,38 +706,41 @@ class Business.Report use-widget-pool:
         if sampleGroup eq "All" then assign sampleGroup = "". /* Normalize the option for all groups. */
 
         /* Return all requests as of the first sample for the given group (or start of sampling). */
-        for each SessionSample no-lock
-           where (sessionUUID eq "" or SessionSample.SessionUUID eq sessionUUID)
-             and (sampleGroup eq "" or SessionSample.SampleGroup eq sampleGroup)
-              by SessionSample.Timestamp:
+        sampleblk:
+        for each bSessionSample no-lock
+           where bSessionSample.SessionUUID eq sessionUUID
+              by bSessionSample.Timestamp:
+            /* Move to the next if a sample group was named but this record is not in that group. */ 
+            if sampleGroup gt "" and bSessionSample.SampleGroup ne sampleGroup then next sampleblk.
+            
             /* If a sample date is provided but date does not match, skip the sample.*/
-            if sampleDate ne ? and date(SessionSample.Timestamp) ne sampleDate then next.
+            if sampleDate ne ? and date(bSessionSample.Timestamp) ne sampleDate then next sampleblk.
 
             /* Return a list of objects for a given sample interval. */
-            for each RequestInfo no-lock
-               where RequestInfo.SampleUUID eq SessionSample.SampleUUID:
+            for each bRequestInfo no-lock
+               where bRequestInfo.SampleUUID eq bSessionSample.SampleUUID:
                 create ablRequest.
                 assign
-                    ablRequest.agentSessionUUID = RequestInfo.SessionUUID
-                    ablRequest.requestUUID      = RequestInfo.RequestUUID
-                    ablRequest.requestNum       = RequestInfo.RequestNum
-                    ablRequest.requestID        = substitute("&1:&2:&3", RequestInfo.WebAppName, RequestInfo.Transport, RequestInfo.RequestID)
-                    ablRequest.programName      = RequestInfo.ProcName
-                    ablRequest.startTime        = string(RequestInfo.StartTime)
-                    ablRequest.endTime          = string(RequestInfo.EndTime)
-                    ablRequest.elapsedTime      = RequestInfo.Elapsed
+                    ablRequest.agentSessionUUID = bRequestInfo.SessionUUID
+                    ablRequest.requestUUID      = bRequestInfo.RequestUUID
+                    ablRequest.requestNum       = bRequestInfo.RequestNum
+                    ablRequest.requestID        = substitute("&1:&2:&3", bRequestInfo.WebAppName, bRequestInfo.Transport, bRequestInfo.RequestID)
+                    ablRequest.programName      = bRequestInfo.ProcName
+                    ablRequest.startTime        = string(bRequestInfo.StartTime)
+                    ablRequest.endTime          = string(bRequestInfo.EndTime)
+                    ablRequest.elapsedTime      = bRequestInfo.Elapsed
                     ablRequest.hasCallTree      = false
                     ablRequest.hasProfiler      = false
                     .
 
                 for first CallTree no-lock
-                    where CallTree.RequestUUID eq RequestInfo.RequestUUID:
+                    where CallTree.RequestUUID eq bRequestInfo.RequestUUID:
                     assign ablRequest.hasCallTree = true.
                 end. /* for first CallTree */
 
                 for first ProfilerData no-lock
                     where ProfilerData.SessionUUID eq sessionUUID
-                      and ProfilerData.Timestamp eq RequestInfo.StartTime:
+                      and ProfilerData.Timestamp eq bRequestInfo.StartTime:
                     assign
                         ablRequest.hasProfiler = true
                         ablRequest.profilerRec = string(rowid(ProfilerData))
@@ -694,7 +749,7 @@ class Business.Report use-widget-pool:
 
                 /* Add any available CallStack entries to the appropriate table. */
                 for each CallStack no-lock
-                   where CallStack.RequestUUID eq RequestInfo.RequestUUID:
+                   where CallStack.RequestUUID eq bRequestInfo.RequestUUID:
                     create requestStack.
                     assign
                         requestStack.requestUUID = CallStack.RequestUUID
@@ -707,8 +762,8 @@ class Business.Report use-widget-pool:
                 end. /* for each CallStack */
 
                 release ablRequest no-error.
-            end. /* for each RequestInfo */
-        end. /* for each SessionSample */
+            end. /* for each bRequestInfo */
+        end. /* for each bSessionSample */
     end method. /* GetRequests */
 
 
@@ -724,20 +779,23 @@ class Business.Report use-widget-pool:
         define variable lcTemp  as longchar  no-undo initial "".
         define variable cTemp   as character no-undo.
 
-        find first RequestInfo no-lock
-             where RequestInfo.RequestUUID eq requestUUID no-error.
-        if not available(RequestInfo) then return.
+        define buffer bCallTree    for CallTree.
+        define buffer bRequestInfo for RequestInfo.
+
+        find first bRequestInfo no-lock
+             where bRequestInfo.RequestUUID eq requestUUID no-error.
+        if not available(bRequestInfo) then return.
 
         /* Use version 4 of the profiler output which includes the calltree section. */
         /* This also provides some basic but useful AVM Information for the final report. */
         assign callTreeData = substitute('4 &1 "Call-Tree for Request #&2" &3 "" ~{~}~n.',
-                                         trim(string(RequestInfo.StartTime, "99/99/9999")), RequestInfo.RequestNum,
-                                         trim(string(integer(truncate(mtime(RequestInfo.StartTime) / 1000, 0))), "HH:MM:SS")).
+                                         trim(string(bRequestInfo.StartTime, "99/99/9999")), bRequestInfo.RequestNum,
+                                         trim(string(integer(truncate(mtime(bRequestInfo.StartTime) / 1000, 0))), "HH:MM:SS")).
 
         /* Extract the stringified JSON array. */
-        for first CallTree no-lock
-            where CallTree.RequestUUID eq requestUUID:
-            copy-lob CallTree.Data to lcData no-error.
+        for first bCallTree no-lock
+            where bCallTree.RequestUUID eq requestUUID:
+            copy-lob bCallTree.Data to lcData no-error.
         end.
 
         if lcData eq ? or lcData eq "" then return.
@@ -791,32 +849,35 @@ class Business.Report use-widget-pool:
         define variable dStart as datetime    no-undo.
         define variable dEnd   as datetime    no-undo.
 
+        define buffer bRequestInfo   for RequestInfo.
+        define buffer bSessionSample for SessionSample.
+
         assign accessHistory = dataset accessHistory:handle.
 
         empty temp-table tomcatAccess.
         empty temp-table sessionRequest.
 
         /* Determine the first sample for this agent/session to limit the log results. */
-        for first RequestInfo no-lock
-            where RequestInfo.SessionUUID eq sessionUUID:
-            assign dBegin = add-interval(datetime-tz(RequestInfo.StartTime), -1, "minutes").
-        end. /* for first RequestInfo */
+        for first bRequestInfo no-lock
+            where bRequestInfo.SessionUUID eq sessionUUID:
+            assign dBegin = add-interval(datetime-tz(bRequestInfo.StartTime), -1, "minutes").
+        end. /* for first bRequestInfo */
         if dBegin eq ? then /* No requests logged. */
-            for first SessionSample no-lock
-                where SessionSample.SessionUUID eq sessionUUID:
-                assign dBegin = add-interval(datetime-tz(SessionSample.Timestamp), -4, "minutes").
-            end. /* for first SessionSample */
+            for first bSessionSample no-lock
+                where bSessionSample.SessionUUID eq sessionUUID:
+                assign dBegin = add-interval(datetime-tz(bSessionSample.Timestamp), -4, "minutes").
+            end. /* for first bSessionSample */
 
         /* Determine the last sample for this agent/session to limit the log results. */
-        for last RequestInfo no-lock
-           where RequestInfo.SessionUUID eq sessionUUID:
-            assign dLimit = add-interval(datetime-tz(RequestInfo.EndTime), 1, "minutes").
-        end. /* for last RequestInfo */
+        for last bRequestInfo no-lock
+           where bRequestInfo.SessionUUID eq sessionUUID:
+            assign dLimit = add-interval(datetime-tz(bRequestInfo.EndTime), 1, "minutes").
+        end. /* for last bRequestInfo */
         if dBegin eq ? then /* No requests logged. */
-            for last SessionSample no-lock
-               where SessionSample.SessionUUID eq sessionUUID:
-                assign dLimit = add-interval(datetime-tz(SessionSample.Timestamp), 4, "minutes").
-            end. /* for last SessionSample */
+            for last bSessionSample no-lock
+               where bSessionSample.SessionUUID eq sessionUUID:
+                assign dLimit = add-interval(datetime-tz(bSessionSample.Timestamp), 4, "minutes").
+            end. /* for last bSessionSample */
 
         /* Look through the access log entries, previously limited to just transport and security endpoints. */
         for each AccessLog no-lock
@@ -849,23 +910,23 @@ class Business.Report use-widget-pool:
                 .
 
             /* Locate any ABL requests that may have occurred during the elapsed time of the access. */
-            for each RequestInfo no-lock
-               where RequestInfo.ServerUUID eq AccessLog.ServerUUID
-                 and RequestInfo.StartTime ge dStart
-                 and RequestInfo.EndTime le dEnd:
+            for each bRequestInfo no-lock
+               where bRequestInfo.ServerUUID eq AccessLog.ServerUUID
+                 and bRequestInfo.StartTime ge dStart
+                 and bRequestInfo.EndTime le dEnd:
                 create sessionRequest.
                 assign
                     sessionRequest.accessOrder  = iCount
-                    sessionRequest.requestNum   = RequestInfo.RequestNum
-                    sessionRequest.requestID    = substitute("&1:&2:&3", RequestInfo.WebAppName, RequestInfo.Transport, RequestInfo.RequestID)
-                    sessionRequest.programName  = RequestInfo.ProcName
-                    sessionRequest.startTime    = string(RequestInfo.StartTime)
-                    sessionRequest.endTime      = string(RequestInfo.EndTime)
-                    sessionRequest.elapsedTime  = RequestInfo.Elapsed
+                    sessionRequest.requestNum   = bRequestInfo.RequestNum
+                    sessionRequest.requestID    = substitute("&1:&2:&3", bRequestInfo.WebAppName, bRequestInfo.Transport, bRequestInfo.RequestID)
+                    sessionRequest.programName  = bRequestInfo.ProcName
+                    sessionRequest.startTime    = string(bRequestInfo.StartTime)
+                    sessionRequest.endTime      = string(bRequestInfo.EndTime)
+                    sessionRequest.elapsedTime  = bRequestInfo.Elapsed
                     .
 
                 /* Track total time for internal ABL requests found. */
-                assign iTime = iTime + RequestInfo.Elapsed.
+                assign iTime = iTime + bRequestInfo.Elapsed.
                 release sessionRequest no-error.
             end. /* for each ABLObject */
 
@@ -918,11 +979,13 @@ class Business.Report use-widget-pool:
     @progress.service.resourceMapping(type="REST", operation="invoke", URI="/profilerData", alias="profilerData", mediaType="application/json").
     method public void GetProfilerData ( input  profilerRowID as character,
                                          output profilerOut   as longchar ):
+        define buffer bProfiler for ProfilerData.
+
         /* Return the profiler data for the exact record. */
-        for first ProfilerData no-lock
-            where rowid(ProfilerData) eq to-rowid(profilerRowID):
-            copy-lob from ProfilerData.CodeProfile to profilerOut no-error.
-        end. /* for first ProfilerData */
+        for first bProfiler no-lock
+            where rowid(bProfiler) eq to-rowid(profilerRowID):
+            copy-lob from bProfiler.CodeProfile to profilerOut no-error.
+        end. /* for first bProfiler */
     end method. /* GetProfilerData */
 
 
@@ -1074,6 +1137,9 @@ class Business.Report use-widget-pool:
         define variable iOSHealth as integer     no-undo.
         define variable iTomcatID as integer     no-undo.
 
+        define buffer bConfig for HealthCheckConfig.
+        define buffer bData   for HealthCheckData.
+
         assign healthTrend = dataset healthTrend:handle.
 
         if (serverUUID gt "") ne true then undo, throw new AppError("Server UUID Missing", 0).
@@ -1086,96 +1152,96 @@ class Business.Report use-widget-pool:
             assign trendPeriod = 1.
 
         /* Track the overall health probe (ID 1). */
-        for first HealthCheckConfig no-lock
-            where HealthCheckConfig.ServerUUID eq serverUUID
-              and HealthCheckConfig.probeid eq 1:
+        for first bConfig no-lock
+            where bConfig.ServerUUID eq serverUUID
+              and bConfig.probeid eq 1:
             create healthProbe.
             assign
-                healthProbe.probeID   = HealthCheckConfig.probeid
-                healthProbe.parentID  = HealthCheckConfig.parentid
-                healthProbe.probeName = HealthCheckConfig.config_name
+                healthProbe.probeID   = bConfig.probeid
+                healthProbe.parentID  = bConfig.parentid
+                healthProbe.probeName = bConfig.config_name
                 .
         end. /* for first HealthConfig */
 
         /* Get all of the top-level probes under the overall health probe (ID 1). */
-        for each HealthCheckConfig no-lock
-           where HealthCheckConfig.ServerUUID eq serverUUID
-             and HealthCheckConfig.parentid eq 1
-             and HealthCheckConfig.enabled:
+        for each bConfig no-lock
+           where bConfig.ServerUUID eq serverUUID
+             and bConfig.parentid eq 1
+             and bConfig.enabled:
             /* Skip if we somehow find a duplicate of this probeID. */
-            if can-find(first healthProbe where healthProbe.probeID eq HealthCheckConfig.probeid no-lock) then next.
+            if can-find(first healthProbe where healthProbe.probeID eq bConfig.probeid no-lock) then next.
 
             /* Ignore the overall OS Health score for later. */
-            if HealthCheckConfig.config_name eq "OS Health" then
-                assign iOSHealth = HealthCheckConfig.probeid.
+            if bConfig.config_name eq "OS Health" then
+                assign iOSHealth = bConfig.probeid.
             else do:
                 create healthProbe.
                 assign
-                    healthProbe.probeID   = HealthCheckConfig.probeid
-                    healthProbe.parentID  = HealthCheckConfig.parentid
-                    healthProbe.probeName = HealthCheckConfig.config_name
+                    healthProbe.probeID   = bConfig.probeid
+                    healthProbe.parentID  = bConfig.parentid
+                    healthProbe.probeName = bConfig.config_name
                     .
 
                 /* Remember the probeID for the Tomcat Health. */
-                if HealthCheckConfig.config_name eq "Tomcat Health" then
-                    assign iTomcatID = HealthCheckConfig.probeid.
+                if bConfig.config_name eq "Tomcat Health" then
+                    assign iTomcatID = bConfig.probeid.
             end.
         end. /* for each HealthConfig */
 
         /* Add the individual OS Health probes which may be of more interest. */
-        for each HealthCheckConfig no-lock
-           where HealthCheckConfig.ServerUUID eq serverUUID
-             and HealthCheckConfig.parentid eq iOSHealth
-             and HealthCheckConfig.enabled:
+        for each bConfig no-lock
+           where bConfig.ServerUUID eq serverUUID
+             and bConfig.parentid eq iOSHealth
+             and bConfig.enabled:
             /* Skip if we somehow find a duplicate of this probeID. */
-            if can-find(first healthProbe where healthProbe.probeID eq HealthCheckConfig.probeid no-lock) then next.
+            if can-find(first healthProbe where healthProbe.probeID eq bConfig.probeid no-lock) then next.
 
             create healthProbe.
             assign
-                healthProbe.probeID   = HealthCheckConfig.probeid
-                healthProbe.parentID  = HealthCheckConfig.parentid
-                healthProbe.probeName = HealthCheckConfig.config_name
+                healthProbe.probeID   = bConfig.probeid
+                healthProbe.parentID  = bConfig.parentid
+                healthProbe.probeName = bConfig.config_name
                 .
         end. /* for each HealthConfig */
 
         /* Add the individual Tomcat Health probes which may be of more interest. */
-        for each HealthCheckConfig no-lock
-           where HealthCheckConfig.ServerUUID eq serverUUID
-             and HealthCheckConfig.parentid eq iTomcatID
-             and HealthCheckConfig.enabled:
+        for each bConfig no-lock
+           where bConfig.ServerUUID eq serverUUID
+             and bConfig.parentid eq iTomcatID
+             and bConfig.enabled:
             /* Skip if we somehow find a duplicate of this probeID. */
-            if can-find(first healthProbe where healthProbe.probeID eq HealthCheckConfig.probeid no-lock) then next.
+            if can-find(first healthProbe where healthProbe.probeID eq bConfig.probeid no-lock) then next.
 
             create healthProbe.
             assign
-                healthProbe.probeID   = HealthCheckConfig.probeid
-                healthProbe.parentID  = HealthCheckConfig.parentid
-                healthProbe.probeName = HealthCheckConfig.config_name
+                healthProbe.probeID   = bConfig.probeid
+                healthProbe.parentID  = bConfig.parentid
+                healthProbe.probeName = bConfig.config_name
                 .
         end. /* for each HealthConfig */
 
         /* Find the last (non-ignored) data point for this serverUUID. */
-        for last HealthCheckData no-lock
-           where HealthCheckData.ServerUUID eq serverUUID
-             and not HealthCheckData.ignore
-              by HealthCheckData.lastpoll:
-            assign dLastTime = HealthCheckData.lastpoll.
+        for last bData no-lock
+           where bData.ServerUUID eq serverUUID
+             and not bData.ignore
+              by bData.lastpoll:
+            assign dLastTime = bData.lastpoll.
         end.
 
         /* Get data for every probe found within the last-specified trend period. */
         for each healthProbe no-lock:
-            for each HealthCheckData no-lock
-               where HealthCheckData.ServerUUID eq serverUUID
-                 and HealthCheckData.probeid eq healthProbe.probeID
-                 and HealthCheckData.lastpoll ge add-interval(dLastTime, (trendPeriod * -1), "hours")
-                 and not HealthCheckData.ignore:
+            for each bData no-lock
+               where bData.ServerUUID eq serverUUID
+                 and bData.probeid eq healthProbe.probeID
+                 and bData.lastpoll ge add-interval(dLastTime, (trendPeriod * -1), "hours")
+                 and not bData.ignore:
                 create probeData.
                 assign
-                    probeData.probeID    = HealthCheckData.probeid
-                    probeData.health     = (HealthCheckData.health * 100) /* Return as a percentage out of 100. */
-                    probeData.isMarginal = HealthCheckData.marginal
-                    probeData.isCritical = HealthCheckData.critical
-                    probeData.pollTime   = HealthCheckData.lastpoll
+                    probeData.probeID    = bData.probeid
+                    probeData.health     = (bData.health * 100) /* Return as a percentage out of 100. */
+                    probeData.isMarginal = bData.marginal
+                    probeData.isCritical = bData.critical
+                    probeData.pollTime   = bData.lastpoll
                     .
             end. /* for each HealthData */
         end. /* for each healthProbe */

--- a/PAS/Monitoring/Collector/ablapps/Business/Report.cls
+++ b/PAS/Monitoring/Collector/ablapps/Business/Report.cls
@@ -37,6 +37,10 @@ class Business.Report use-widget-pool:
     {Common/health.i}
     {Common/report.i}
 
+    define private temp-table ttDate
+        field sampleDate as date
+        .
+
     define private temp-table ttGroup
         field timestamp   as datetime-tz
         field sampleGroup as character
@@ -95,7 +99,8 @@ class Business.Report use-widget-pool:
     @openapi.openedge.export(type="REST", useReturnValue="false", writeDataSetBeforeImage="false").
     @progress.service.resourceMapping(type="REST", operation="invoke", URI="/servers", alias="servers", mediaType="application/json").
     method public void GetServerList ( output appServer as handle ):
-        define variable iGrpCount as integer no-undo.
+        define variable iDateCount as integer no-undo.
+        define variable iGrpCount  as integer no-undo.
 
         assign appServer = temp-table appServer:handle.
 
@@ -111,7 +116,7 @@ class Business.Report use-widget-pool:
                 appServer.appServerUUID   = ServerInfo.ServerUUID
                 .
 
-            /* First, find all sample groups for this agent. */
+            /* Find all sample groups for this agent. */
             empty temp-table ttGroup.
             for each AgentSample no-lock
                where AgentSample.ServerUUID eq ServerInfo.ServerUUID
@@ -125,7 +130,18 @@ class Business.Report use-widget-pool:
                 end.
             end. /* for each ServerInfo */
 
-            /* Next, add only the last 10 group names in reverse chronological order. */
+            /* Find all sample dates for this agent. */
+            empty temp-table ttDate.
+            for each AgentSample no-lock
+               where AgentSample.ServerUUID eq ServerInfo.ServerUUID
+               break by AgentSample.Timestamp:
+                if not can-find(first ttDate where ttDate.sampleDate eq date(AgentSample.Timestamp)) then do:
+                    create ttDate.
+                    assign ttDate.sampleDate = date(AgentSample.Timestamp).
+                end.
+            end. /* for each ServerInfo */
+
+            /* Add only the last 10 group names in reverse chronological order. */
             assign iGrpCount = 1.
             for each ttGroup no-lock
                   by ttGroup.timestamp descending:
@@ -133,6 +149,15 @@ class Business.Report use-widget-pool:
                     appServer.sampleGroup[iGrpCount] = ttGroup.SampleGroup.
                 assign iGrpCount = iGrpCount + 1.
             end. /* for each ttGroup */
+
+            /* Add only the last 10 dates in reverse chronological order. */
+            assign iDateCount = 1.
+            for each ttDate no-lock
+                  by ttDate.sampleDate descending:
+                if iDateCount le 10 then
+                    appServer.sampleDate[iDateCount] = ttDate.sampleDate.
+                assign iDateCount = iDateCount + 1.
+            end. /* for each iDateCount */
 
             release appServer no-error.
         end. /* for each ServerInfo*/
@@ -308,6 +333,7 @@ class Business.Report use-widget-pool:
     method public void GetAgentMetrics ( input  serverUUID   as character,
                                          input  agentPID     as integer,
                                          input  sessionID    as integer,
+                                         input  sampleDate   as date,
                                          input  sampleGroup  as character,
                                          output agentMetrics as handle ):
         define variable lSuccess    as logical  no-undo.
@@ -352,6 +378,9 @@ class Business.Report use-widget-pool:
                     .
                 release instanceAgent no-error.
             end.
+
+            /* If a sample date is provided but date does not match, skip the sample.*/
+            if sampleDate ne ? and date(AgentSample.Timestamp) ne sampleDate then next.
 
             create agentStat.
             assign
@@ -445,6 +474,9 @@ class Business.Report use-widget-pool:
                where SessionSample.SessionUUID eq SessionInfo.SessionUUID
                  and (sampleGroup eq "" or SessionSample.SampleGroup eq sampleGroup)
                   by SessionSample.Timestamp:
+                /* If a sample date is provided but date does not match, skip the sample.*/
+                if sampleDate ne ? and date(SessionSample.Timestamp) ne sampleDate then next.
+
                 /* Count the total samples reported for this session. */
                 assign iSmplCount = iSmplCount + 1.
 
@@ -611,6 +643,7 @@ class Business.Report use-widget-pool:
     @openapi.openedge.export(type="REST", useReturnValue="false", writeDataSetBeforeImage="false").
     @progress.service.resourceMapping(type="REST", operation="invoke", URI="/requests", alias="requests", mediaType="application/json").
     method public void GetRequests ( input  sessionUUID     as character,
+                                     input  sampleDate      as date,
                                      input  sampleGroup     as character,
                                      output ablRequestStack as handle ):
         assign ablRequestStack = dataset ablRequestStack:handle.
@@ -625,6 +658,8 @@ class Business.Report use-widget-pool:
            where (sessionUUID eq "" or SessionSample.SessionUUID eq sessionUUID)
              and (sampleGroup eq "" or SessionSample.SampleGroup eq sampleGroup)
               by SessionSample.Timestamp:
+            /* If a sample date is provided but date does not match, skip the sample.*/
+            if sampleDate ne ? and date(SessionSample.Timestamp) ne sampleDate then next.
 
             /* Return a list of objects for a given sample interval. */
             for each RequestInfo no-lock

--- a/PAS/Monitoring/Collector/ablapps/Business/Report.cls
+++ b/PAS/Monitoring/Collector/ablapps/Business/Report.cls
@@ -352,9 +352,12 @@ class Business.Report use-widget-pool:
                                          input  sessionID    as integer,
                                          input  sampleDate   as date,
                                          input  sampleGroup  as character,
+                                         input  trendPeriod  as integer,
                                          output agentMetrics as handle ):
         define variable lSuccess    as logical  no-undo initial false.
         define variable lHasSession as logical  no-undo initial false.
+        define variable dTrendStart as datetime no-undo initial ?.
+        define variable dTrendEnd   as datetime no-undo initial ?.
         define variable dLastSample as datetime no-undo initial ?.
         define variable fMemPeak    as decimal  no-undo initial 0. /* Tracked across all sessions for this agent. */
         define variable fMemBytes   as decimal  no-undo initial 0.
@@ -387,6 +390,26 @@ class Business.Report use-widget-pool:
         empty temp-table agentSession.
         empty temp-table sessionStat.
 
+        /* If no trend period is specified, default to 2 hour. */
+        if trendPeriod eq ? or trendPeriod eq 0 then
+            assign trendPeriod = 2.
+
+        /* If no sample date provided, default to today. */
+        if sampleDate eq ? then assign sampleDate = today.
+
+        /* Find the last timestamp collected, to be used as the start of the trend period. */
+        for last bAgentSample no-lock
+           where bAgentSample.ServerUUID eq serverUUID
+             and bAgentSample.AgentPID eq agentPID
+             and bAgentSample.Timestamp gt datetime(sampleDate)
+              by bAgentSample.Timestamp:
+            assign dTrendEnd = bAgentSample.Timestamp.
+        end.
+
+        /* Calculate the starting timestamp based on the trend period and end timestamp. */
+        assign dTrendStart = add-interval(dTrendEnd, (trendPeriod * -1), "hours").
+        if dTrendStart lt datetime(sampleDate) then assign dTrendStart = datetime(sampleDate).
+
         /* Get the agent stats for this server and sample group. */
         sampleblk:
         for each bAgentSample no-lock
@@ -407,8 +430,8 @@ class Business.Report use-widget-pool:
                 release instanceAgent no-error.
             end.
 
-            /* If a sample date is provided but date does not match, skip the sample.*/
-            if sampleDate ne ? and date(bAgentSample.Timestamp) ne sampleDate then next sampleblk.
+            /* Skip samples which are outside the trend period.*/
+            if bAgentSample.Timestamp lt dTrendStart or bAgentSample.Timestamp gt dTrendEnd then next sampleblk.
 
             create agentStat.
             assign
@@ -471,6 +494,7 @@ class Business.Report use-widget-pool:
             firstreqblk:
             for each bSessionSample no-lock
                where bSessionSample.SessionUUID eq bSessionInfo.SessionUUID
+                 and bSessionSample.Timestamp ge add-interval(dTrendStart, (trendPeriod * -1), "hours")
                   by bSessionSample.Timestamp:
                 /* Move to the next if a sample group was named but this record is not in that group. */ 
                 if sampleGroup gt "" and bSessionSample.SampleGroup ne sampleGroup then next firstreqblk.
@@ -518,8 +542,8 @@ class Business.Report use-widget-pool:
                 /* Move to the next if a sample group was named but this record is not in that group. */ 
                 if sampleGroup gt "" and bSessionSample.SampleGroup ne sampleGroup then next sampleblk.
 
-                /* If a sample date is provided but date does not match, skip the sample.*/
-                if sampleDate ne ? and date(bSessionSample.Timestamp) ne sampleDate then next sampleblk.
+                /* Skip samples which are outside the trend period.*/
+                if bSessionSample.Timestamp lt dTrendStart or bSessionSample.Timestamp gt dTrendEnd then next sampleblk.
 
                 /* Count the total samples reported for this session. */
                 assign iSmplCount = iSmplCount + 1.
@@ -1147,9 +1171,9 @@ class Business.Report use-widget-pool:
         empty temp-table healthProbe.
         empty temp-table probeData.
 
-        /* If no trend period is specified, default to 1 hour. */
+        /* If no trend period is specified, default to 2 hour. */
         if trendPeriod eq ? or trendPeriod eq 0 then
-            assign trendPeriod = 1.
+            assign trendPeriod = 2.
 
         /* Track the overall health probe (ID 1). */
         for first bConfig no-lock

--- a/PAS/Monitoring/Collector/ablapps/Common/report.i
+++ b/PAS/Monitoring/Collector/ablapps/Common/report.i
@@ -14,6 +14,7 @@ define temp-table appServer no-undo
     field applicationName as character
     field serverName      as character
     field appServerUUID   as character
+    field sampleDates     as date      extent 10 /* This tracks the last 10 days of collected metrics. */
     field sampleGroup     as character extent 10 /* This tracks the last 10 sample groups for the server/application. */
     index idxAppServer applicationName serverName
     .

--- a/PAS/Monitoring/Collector/ablapps/Common/report.i
+++ b/PAS/Monitoring/Collector/ablapps/Common/report.i
@@ -81,7 +81,9 @@ define temp-table agentSession no-undo
     field totalSamples     as int64
     field lastSample       as datetime
     field agentSessionUUID as character /* Used to relate the sampled statistics to this session. */
-    index idxSessionSort sessionSort
+    index idxSessionSort as primary sessionSort
+    index idxAgentPID               agentPID
+    index idxSessionUUID            agentSessionUUID agentPID
     .
 
 /* Specific sample-based stats per agent-session. */

--- a/PAS/Monitoring/Collector/ablapps/monitor.map
+++ b/PAS/Monitoring/Collector/ablapps/monitor.map
@@ -887,6 +887,15 @@
                   }
                 },
                 {
+                  "ablName": "sampleDate",
+                  "ablType": "DATE",
+                  "ioMode": "INPUT",
+                  "msgElem": {
+                    "type": "field",
+                    "name": "sampleDate"
+                  }
+                },
+                {
                   "ablName": "sampleGroup",
                   "ablType": "CHARACTER",
                   "ioMode": "INPUT",
@@ -961,6 +970,15 @@
                   "msgElem": {
                     "type": "field",
                     "name": "sessionUUID"
+                  }
+                },
+                {
+                  "ablName": "sampleDate",
+                  "ablType": "DATE",
+                  "ioMode": "INPUT",
+                  "msgElem": {
+                    "type": "field",
+                    "name": "sampleDate"
                   }
                 },
                 {

--- a/PAS/Monitoring/Collector/ablapps/monitor.map
+++ b/PAS/Monitoring/Collector/ablapps/monitor.map
@@ -905,6 +905,15 @@
                   }
                 },
                 {
+                  "ablName": "trendPeriod",
+                  "ablType": "INTEGER",
+                  "ioMode": "INPUT",
+                  "msgElem": {
+                    "type": "field",
+                    "name": "trendPeriod"
+                  }
+                },
+                {
                   "ablName": "agentMetrics",
                   "ablType": "HANDLE",
                   "ioMode": "OUTPUT",

--- a/PAS/Monitoring/Collector/schema/pasmon.df
+++ b/PAS/Monitoring/Collector/schema/pasmon.df
@@ -2,267 +2,267 @@ ADD TABLE "ABLObject"
   AREA "Data Area"
   DUMP-NAME "ablobject"
 
-ADD FIELD "Line" OF "ABLObject" AS integer
+ADD FIELD "Line" OF "ABLObject" AS integer 
   FORMAT ">>>,>>>,>>9"
   INITIAL "0"
   MAX-WIDTH 4
   ORDER 50
 
-ADD FIELD "ObjType" OF "ABLObject" AS character
+ADD FIELD "ObjType" OF "ABLObject" AS character 
   FORMAT "x(16)"
   INITIAL ""
   MAX-WIDTH 16
   ORDER 70
 
-ADD FIELD "HandleId" OF "ABLObject" AS int64
+ADD FIELD "HandleId" OF "ABLObject" AS int64 
   DESCRIPTION "Unique handle ID for this object, relative to the session"
   FORMAT ">>>,>>>,>>9"
   INITIAL "0"
   MAX-WIDTH 8
   ORDER 20
 
-ADD FIELD "Source" OF "ABLObject" AS character
+ADD FIELD "Source" OF "ABLObject" AS character 
   FORMAT "x(32)"
   INITIAL ""
   MAX-WIDTH 16
   ORDER 40
 
-ADD FIELD "Name" OF "ABLObject" AS character
+ADD FIELD "Name" OF "ABLObject" AS character 
   FORMAT "x(32)"
   INITIAL ""
   MAX-WIDTH 16
   ORDER 60
 
-ADD FIELD "SampleUUID" OF "ABLObject" AS character
+ADD FIELD "SampleUUID" OF "ABLObject" AS character 
   FORMAT "x(8)"
   INITIAL ""
   MAX-WIDTH 16
   ORDER 10
 
-ADD FIELD "Size" OF "ABLObject" AS int64
+ADD FIELD "Size" OF "ABLObject" AS int64 
   FORMAT "->>>,>>>,>>9"
   INITIAL "0"
   MAX-WIDTH 8
   ORDER 80
 
-ADD FIELD "RequestNum" OF "ABLObject" AS int64
+ADD FIELD "RequestNum" OF "ABLObject" AS int64 
   FORMAT ">>>,>>>,>>>,>>>,>>9"
   INITIAL "0"
   MAX-WIDTH 4
   ORDER 30
 
-ADD FIELD "WebAppName" OF "ABLObject" AS character
+ADD FIELD "WebAppName" OF "ABLObject" AS character 
   FORMAT "x(20)"
   INITIAL ""
   MAX-WIDTH 40
   ORDER 90
 
-ADD FIELD "Transport" OF "ABLObject" AS character
+ADD FIELD "Transport" OF "ABLObject" AS character 
   FORMAT "x(10)"
   INITIAL ""
   MAX-WIDTH 20
   ORDER 100
 
-ADD FIELD "RequestID" OF "ABLObject" AS character
+ADD FIELD "RequestID" OF "ABLObject" AS character 
   FORMAT "x(10)"
   INITIAL ""
   MAX-WIDTH 20
   ORDER 110
 
-ADD INDEX "pukMain" ON "ABLObject"
+ADD INDEX "pukMain" ON "ABLObject" 
   AREA "Index Area"
   UNIQUE
   PRIMARY
-  INDEX-FIELD "SampleUUID" ASCENDING
-  INDEX-FIELD "HandleId" ASCENDING
-  INDEX-FIELD "Source" ASCENDING
-  INDEX-FIELD "Line" ASCENDING
+  INDEX-FIELD "SampleUUID" ASCENDING 
+  INDEX-FIELD "HandleId" ASCENDING 
+  INDEX-FIELD "Source" ASCENDING 
+  INDEX-FIELD "Line" ASCENDING 
 
 ADD TABLE "AccessLog"
   AREA "Data Area"
   DUMP-NAME "accesslog"
 
-ADD FIELD "RequestStart" OF "AccessLog" AS datetime-tz
+ADD FIELD "RequestStart" OF "AccessLog" AS datetime-tz 
   FORMAT "99/99/9999 HH:MM:SS.SSS+HH:MM"
   INITIAL ?
   MAX-WIDTH 12
   ORDER 20
 
-ADD FIELD "RequestPath" OF "AccessLog" AS character
+ADD FIELD "RequestPath" OF "AccessLog" AS character 
   FORMAT "x(200)"
   INITIAL ""
   MAX-WIDTH 400
   ORDER 50
 
-ADD FIELD "RequestVerb" OF "AccessLog" AS character
+ADD FIELD "RequestVerb" OF "AccessLog" AS character 
   FORMAT "x(10)"
   INITIAL ""
   MAX-WIDTH 20
   ORDER 60
 
-ADD FIELD "ResponseCode" OF "AccessLog" AS integer
+ADD FIELD "ResponseCode" OF "AccessLog" AS integer 
   FORMAT ">999"
   INITIAL "0"
   MAX-WIDTH 4
   ORDER 70
 
-ADD FIELD "ResponseSize" OF "AccessLog" AS integer
+ADD FIELD "ResponseSize" OF "AccessLog" AS integer 
   FORMAT ">>>,>>>,>>9"
   INITIAL "0"
   MAX-WIDTH 4
   ORDER 80
 
-ADD FIELD "ResponseTime" OF "AccessLog" AS integer
+ADD FIELD "ResponseTime" OF "AccessLog" AS integer 
   FORMAT ">>>,>>>,>>9"
   INITIAL "0"
   MAX-WIDTH 4
   ORDER 90
 
-ADD FIELD "RequestEnd" OF "AccessLog" AS datetime-tz
+ADD FIELD "RequestEnd" OF "AccessLog" AS datetime-tz 
   FORMAT "99/99/9999 HH:MM:SS.SSS+HH:MM"
   INITIAL ?
   MAX-WIDTH 12
   ORDER 30
 
-ADD FIELD "ServerUUID" OF "AccessLog" AS character
+ADD FIELD "ServerUUID" OF "AccessLog" AS character 
   FORMAT "x(16)"
   INITIAL ""
   MAX-WIDTH 32
   ORDER 10
 
-ADD FIELD "ThreadID" OF "AccessLog" AS integer
+ADD FIELD "ThreadID" OF "AccessLog" AS integer 
   FORMAT ">>>>>9"
   INITIAL "0"
   MAX-WIDTH 4
   ORDER 40
 
-ADD FIELD "Username" OF "AccessLog" AS character
+ADD FIELD "Username" OF "AccessLog" AS character 
   FORMAT "x(40)"
   INITIAL ""
   MAX-WIDTH 80
   ORDER 100
 
-ADD FIELD "WebAppName" OF "AccessLog" AS character
+ADD FIELD "WebAppName" OF "AccessLog" AS character 
   FORMAT "x(20)"
   INITIAL ""
   MAX-WIDTH 40
   ORDER 110
 
-ADD FIELD "Transport" OF "AccessLog" AS character
+ADD FIELD "Transport" OF "AccessLog" AS character 
   FORMAT "x(10)"
   INITIAL ""
   MAX-WIDTH 20
   ORDER 120
 
-ADD FIELD "RequestID" OF "AccessLog" AS character
+ADD FIELD "RequestID" OF "AccessLog" AS character 
   FORMAT "x(10)"
   INITIAL ""
   MAX-WIDTH 20
   ORDER 130
 
-ADD INDEX "pukMain" ON "AccessLog"
+ADD INDEX "pukMain" ON "AccessLog" 
   AREA "Index Area"
   UNIQUE
   PRIMARY
-  INDEX-FIELD "ServerUUID" ASCENDING
-  INDEX-FIELD "RequestStart" ASCENDING
-  INDEX-FIELD "RequestEnd" ASCENDING
+  INDEX-FIELD "ServerUUID" ASCENDING 
+  INDEX-FIELD "RequestStart" ASCENDING 
+  INDEX-FIELD "RequestEnd" ASCENDING 
 
 ADD TABLE "AgentLog"
   AREA "Data Area"
   DUMP-NAME "agentlog"
 
-ADD FIELD "ServerUUID" OF "AgentLog" AS character
+ADD FIELD "ServerUUID" OF "AgentLog" AS character 
   FORMAT "x(16)"
   INITIAL ""
   MAX-WIDTH 32
   ORDER 10
 
-ADD FIELD "AgentPID" OF "AgentLog" AS integer
+ADD FIELD "AgentPID" OF "AgentLog" AS integer 
   FORMAT ">>>>>>>>9"
   INITIAL "0"
   MAX-WIDTH 4
   ORDER 20
 
-ADD FIELD "MsgNum" OF "AgentLog" AS int64
+ADD FIELD "MsgNum" OF "AgentLog" AS int64 
   FORMAT ">>>,>>>,>>>,>>>,>>9"
   INITIAL "0"
   MAX-WIDTH 8
   ORDER 30
 
-ADD FIELD "RawMessage" OF "AgentLog" AS character
+ADD FIELD "RawMessage" OF "AgentLog" AS character 
   FORMAT "x(200)"
   INITIAL ""
   MAX-WIDTH 400
   ORDER 40
 
-ADD FIELD "Timestamp" OF "AgentLog" AS datetime-tz
+ADD FIELD "Timestamp" OF "AgentLog" AS datetime-tz 
   FORMAT "99/99/9999 HH:MM:SS.SSS+HH:MM"
   INITIAL ?
   MAX-WIDTH 12
   ORDER 50
 
-ADD FIELD "WebAppName" OF "AgentLog" AS character
+ADD FIELD "WebAppName" OF "AgentLog" AS character 
   FORMAT "x(20)"
   INITIAL ""
   MAX-WIDTH 40
   ORDER 60
 
-ADD FIELD "Transport" OF "AgentLog" AS character
+ADD FIELD "Transport" OF "AgentLog" AS character 
   FORMAT "x(10)"
   INITIAL ""
   MAX-WIDTH 20
   ORDER 70
 
-ADD FIELD "RequestID" OF "AgentLog" AS character
+ADD FIELD "RequestID" OF "AgentLog" AS character 
   FORMAT "x(10)"
   INITIAL ""
   MAX-WIDTH 20
   ORDER 80
 
-ADD FIELD "MsgType" OF "AgentLog" AS character
+ADD FIELD "MsgType" OF "AgentLog" AS character 
   FORMAT "x(12)"
   INITIAL ""
   MAX-WIDTH 24
   ORDER 90
 
-ADD FIELD "MessageText" OF "AgentLog" AS character
+ADD FIELD "MessageText" OF "AgentLog" AS character 
   FORMAT "x(200)"
   INITIAL ""
   MAX-WIDTH 400
   ORDER 100
 
-ADD INDEX "pukAgentMsg" ON "AgentLog"
+ADD INDEX "pukAgentMsg" ON "AgentLog" 
   AREA "Index Area"
   UNIQUE
   PRIMARY
-  INDEX-FIELD "ServerUUID" ASCENDING
-  INDEX-FIELD "AgentPID" ASCENDING
-  INDEX-FIELD "MsgNum" ASCENDING
+  INDEX-FIELD "ServerUUID" ASCENDING 
+  INDEX-FIELD "AgentPID" ASCENDING 
+  INDEX-FIELD "MsgNum" ASCENDING 
 
 ADD TABLE "AgentLogRaw"
   AREA "Data Area"
   DUMP-NAME "agentlograw"
 
-ADD FIELD "ServerUUID" OF "AgentLogRaw" AS character
+ADD FIELD "ServerUUID" OF "AgentLogRaw" AS character 
   FORMAT "x(16)"
   INITIAL ""
   MAX-WIDTH 32
   ORDER 10
 
-ADD FIELD "AgentPID" OF "AgentLogRaw" AS integer
+ADD FIELD "AgentPID" OF "AgentLogRaw" AS integer 
   FORMAT ">>>>>>>>9"
   INITIAL "0"
   MAX-WIDTH 4
   ORDER 20
 
-ADD FIELD "Timestamp" OF "AgentLogRaw" AS datetime-tz
+ADD FIELD "Timestamp" OF "AgentLogRaw" AS datetime-tz 
   FORMAT "99/99/9999 HH:MM:SS.SSS+HH:MM"
   INITIAL ?
   MAX-WIDTH 12
   ORDER 30
 
-ADD FIELD "MessageData" OF "AgentLogRaw" AS clob
+ADD FIELD "MessageData" OF "AgentLogRaw" AS clob 
   FORMAT "x(8)"
   INITIAL ?
   LOB-AREA "LOB Area"
@@ -273,149 +273,149 @@ ADD FIELD "MessageData" OF "AgentLogRaw" AS clob
   CLOB-TYPE 2
   ORDER 60
 
-ADD FIELD "MsgSequence" OF "AgentLogRaw" AS int64
+ADD FIELD "MsgSequence" OF "AgentLogRaw" AS int64 
   FORMAT ">>>,>>>,>>>,>>9"
   INITIAL "0"
   MAX-WIDTH 8
   ORDER 40
 
-ADD FIELD "MsgCount" OF "AgentLogRaw" AS int64
+ADD FIELD "MsgCount" OF "AgentLogRaw" AS int64 
   FORMAT ">>>,>>>,>>>,>>9"
   INITIAL "0"
   MAX-WIDTH 8
   ORDER 50
 
-ADD INDEX "pukMain" ON "AgentLogRaw"
+ADD INDEX "pukMain" ON "AgentLogRaw" 
   AREA "Index Area"
   UNIQUE
   PRIMARY
-  INDEX-FIELD "ServerUUID" ASCENDING
-  INDEX-FIELD "AgentPID" ASCENDING
-  INDEX-FIELD "Timestamp" ASCENDING
+  INDEX-FIELD "ServerUUID" ASCENDING 
+  INDEX-FIELD "AgentPID" ASCENDING 
+  INDEX-FIELD "Timestamp" ASCENDING 
 
 ADD TABLE "AgentSample"
   AREA "Data Area"
   DUMP-NAME "agentsample"
 
-ADD FIELD "ServerUUID" OF "AgentSample" AS character
+ADD FIELD "ServerUUID" OF "AgentSample" AS character 
   FORMAT "x(16)"
   INITIAL ""
   MAX-WIDTH 32
   ORDER 10
 
-ADD FIELD "AgentPID" OF "AgentSample" AS integer
+ADD FIELD "AgentPID" OF "AgentSample" AS integer 
   FORMAT ">>>>>>>>9"
   INITIAL "0"
   MAX-WIDTH 4
   ORDER 20
 
-ADD FIELD "AgentStarted" OF "AgentSample" AS datetime
+ADD FIELD "AgentStarted" OF "AgentSample" AS datetime 
   DESCRIPTION "Timestamp of when this agent was started."
   FORMAT "99/99/9999 HH:MM:SS.SSS"
   INITIAL ?
   MAX-WIDTH 8
   ORDER 30
 
-ADD FIELD "SampleGroup" OF "AgentSample" AS character
+ADD FIELD "SampleGroup" OF "AgentSample" AS character 
   FORMAT "x(20)"
   INITIAL ""
   MAX-WIDTH 40
   HELP "User-defined name for current sample grouping."
   ORDER 40
 
-ADD FIELD "Timestamp" OF "AgentSample" AS datetime
+ADD FIELD "Timestamp" OF "AgentSample" AS datetime 
   FORMAT "99/99/9999 HH:MM:SS.SSS"
   INITIAL ?
   MAX-WIDTH 8
   ORDER 50
 
-ADD FIELD "BusySessions" OF "AgentSample" AS integer
+ADD FIELD "BusySessions" OF "AgentSample" AS integer 
   DESCRIPTION "Count of sessions which had activity since last sample."
   FORMAT ">>>,>>9"
   INITIAL "0"
   MAX-WIDTH 4
   ORDER 60
 
-ADD FIELD "ActiveSessions" OF "AgentSample" AS character
+ADD FIELD "ActiveSessions" OF "AgentSample" AS character 
   DESCRIPTION "List of session ID's which were seen during this sample."
   FORMAT "x(200)"
   INITIAL ""
   MAX-WIDTH 400
   ORDER 70
 
-ADD FIELD "OverheadMemory" OF "AgentSample" AS int64
+ADD FIELD "OverheadMemory" OF "AgentSample" AS int64 
   DESCRIPTION "Overhead memory reported by the agent at the time of this sample"
   FORMAT ">>>,>>>,>>>,>>>,>>9"
   INITIAL "0"
   MAX-WIDTH 8
   ORDER 80
 
-ADD INDEX "pukMain" ON "AgentSample"
+ADD INDEX "pukMain" ON "AgentSample" 
   AREA "Index Area"
   UNIQUE
   PRIMARY
-  INDEX-FIELD "ServerUUID" ASCENDING
-  INDEX-FIELD "AgentPID" ASCENDING
-  INDEX-FIELD "Timestamp" ASCENDING
+  INDEX-FIELD "ServerUUID" ASCENDING 
+  INDEX-FIELD "AgentPID" ASCENDING 
+  INDEX-FIELD "Timestamp" ASCENDING 
 
-ADD INDEX "idxSample" ON "AgentSample"
-  AREA "Data Area"
-  INDEX-FIELD "ServerUUID" ASCENDING
-  INDEX-FIELD "AgentPID" ASCENDING
-  INDEX-FIELD "SampleGroup" ASCENDING
+ADD INDEX "idxServerTime" ON "AgentSample" 
+  AREA "Index Area"
+  INDEX-FIELD "ServerUUID" ASCENDING 
+  INDEX-FIELD "AgentPID" ASCENDING 
+  INDEX-FIELD "Timestamp" ASCENDING 
 
 ADD TABLE "CallStack"
   AREA "Data Area"
   DUMP-NAME "callstack"
 
-ADD FIELD "RequestUUID" OF "CallStack" AS character
+ADD FIELD "RequestUUID" OF "CallStack" AS character 
   FORMAT "x(32)"
   INITIAL ""
   MAX-WIDTH 64
   ORDER 10
 
-ADD FIELD "StackOrder" OF "CallStack" AS integer
+ADD FIELD "StackOrder" OF "CallStack" AS integer 
   FORMAT ">>9"
   INITIAL "0"
   MAX-WIDTH 4
   ORDER 20
 
-ADD FIELD "Line" OF "CallStack" AS integer
+ADD FIELD "Line" OF "CallStack" AS integer 
   FORMAT ">>>,>>>,>>9"
   INITIAL "0"
   MAX-WIDTH 4
   ORDER 30
 
-ADD FIELD "Routine" OF "CallStack" AS character
+ADD FIELD "Routine" OF "CallStack" AS character 
   FORMAT "x(64)"
   INITIAL ""
   MAX-WIDTH 128
   ORDER 40
 
-ADD FIELD "Source" OF "CallStack" AS character
+ADD FIELD "Source" OF "CallStack" AS character 
   FORMAT "x(64)"
   INITIAL ""
   MAX-WIDTH 128
   ORDER 50
 
-ADD INDEX "pukMain" ON "CallStack"
+ADD INDEX "pukMain" ON "CallStack" 
   AREA "Index Area"
   UNIQUE
   PRIMARY
-  INDEX-FIELD "RequestUUID" ASCENDING
-  INDEX-FIELD "StackOrder" ASCENDING
+  INDEX-FIELD "RequestUUID" ASCENDING 
+  INDEX-FIELD "StackOrder" ASCENDING 
 
 ADD TABLE "CallTree"
   AREA "Data Area"
   DUMP-NAME "calltree"
 
-ADD FIELD "RequestUUID" OF "CallTree" AS character
+ADD FIELD "RequestUUID" OF "CallTree" AS character 
   FORMAT "x(32)"
   INITIAL ""
   MAX-WIDTH 64
   ORDER 10
 
-ADD FIELD "Data" OF "CallTree" AS clob
+ADD FIELD "Data" OF "CallTree" AS clob 
   FORMAT "x(8)"
   INITIAL ?
   LOB-AREA "LOB Area"
@@ -426,60 +426,60 @@ ADD FIELD "Data" OF "CallTree" AS clob
   CLOB-TYPE 2
   ORDER 20
 
-ADD INDEX "pukMain" ON "CallTree"
+ADD INDEX "pukMain" ON "CallTree" 
   AREA "Index Area"
   UNIQUE
   PRIMARY
-  INDEX-FIELD "RequestUUID" ASCENDING
+  INDEX-FIELD "RequestUUID" ASCENDING 
 
 ADD TABLE "HealthCheckConfig"
   AREA "Data Area"
   DESCRIPTION "HealthCheck Config Values"
   DUMP-NAME "healthconfig"
 
-ADD FIELD "probeid" OF "HealthCheckConfig" AS integer
+ADD FIELD "probeid" OF "HealthCheckConfig" AS integer 
   DESCRIPTION "Probe Identifier"
   FORMAT ">>9"
   INITIAL "0"
   MAX-WIDTH 4
   ORDER 20
 
-ADD FIELD "parentid" OF "HealthCheckConfig" AS integer
+ADD FIELD "parentid" OF "HealthCheckConfig" AS integer 
   DESCRIPTION "Parent Probe ID"
   FORMAT ">>9"
   INITIAL "0"
   MAX-WIDTH 4
   ORDER 30
 
-ADD FIELD "composite" OF "HealthCheckConfig" AS logical
+ADD FIELD "composite" OF "HealthCheckConfig" AS logical 
   DESCRIPTION "Is probe a composite?"
   FORMAT "yes/no"
   INITIAL "no"
   MAX-WIDTH 1
   ORDER 40
 
-ADD FIELD "config_name" OF "HealthCheckConfig" AS character
+ADD FIELD "config_name" OF "HealthCheckConfig" AS character 
   DESCRIPTION "Configured Probe Name"
   FORMAT "x(64)"
   INITIAL ""
   MAX-WIDTH 128
   ORDER 50
 
-ADD FIELD "timestamp" OF "HealthCheckConfig" AS datetime-tz
+ADD FIELD "timestamp" OF "HealthCheckConfig" AS datetime-tz 
   DESCRIPTION "Config value as of date/time"
   FORMAT "99/99/9999 HH:MM:SS.SSS+HH:MM"
   INITIAL ?
   MAX-WIDTH 12
   ORDER 60
 
-ADD FIELD "calculation" OF "HealthCheckConfig" AS character
+ADD FIELD "calculation" OF "HealthCheckConfig" AS character 
   DESCRIPTION "Calculated probe value formula"
   FORMAT "x(64)"
   INITIAL ""
   MAX-WIDTH 128
   ORDER 70
 
-ADD FIELD "critical" OF "HealthCheckConfig" AS decimal
+ADD FIELD "critical" OF "HealthCheckConfig" AS decimal 
   DESCRIPTION "Critical Probe Value"
   FORMAT ">>9.9"
   INITIAL "0"
@@ -487,7 +487,7 @@ ADD FIELD "critical" OF "HealthCheckConfig" AS decimal
   DECIMALS 1
   ORDER 80
 
-ADD FIELD "marginal" OF "HealthCheckConfig" AS decimal
+ADD FIELD "marginal" OF "HealthCheckConfig" AS decimal 
   DESCRIPTION "Marginal Probe Value"
   FORMAT ">>9.99"
   INITIAL "0"
@@ -495,14 +495,14 @@ ADD FIELD "marginal" OF "HealthCheckConfig" AS decimal
   DECIMALS 1
   ORDER 90
 
-ADD FIELD "description" OF "HealthCheckConfig" AS character
+ADD FIELD "description" OF "HealthCheckConfig" AS character 
   DESCRIPTION "Probe Description"
   FORMAT "x(64)"
   INITIAL ""
   MAX-WIDTH 128
   ORDER 100
 
-ADD FIELD "weight" OF "HealthCheckConfig" AS decimal
+ADD FIELD "weight" OF "HealthCheckConfig" AS decimal 
   DESCRIPTION "Weight of probe in overall formula"
   FORMAT ">>9.99"
   INITIAL "0"
@@ -510,28 +510,28 @@ ADD FIELD "weight" OF "HealthCheckConfig" AS decimal
   DECIMALS 1
   ORDER 110
 
-ADD FIELD "className" OF "HealthCheckConfig" AS character
+ADD FIELD "className" OF "HealthCheckConfig" AS character 
   DESCRIPTION "Probe ABL Class Name"
   FORMAT "x(64)"
   INITIAL ""
   MAX-WIDTH 128
   ORDER 120
 
-ADD FIELD "enabled" OF "HealthCheckConfig" AS logical
+ADD FIELD "enabled" OF "HealthCheckConfig" AS logical 
   DESCRIPTION "Is probe enabled?"
   FORMAT "yes/no"
   INITIAL "no"
   MAX-WIDTH 1
   ORDER 130
 
-ADD FIELD "failOnCritical" OF "HealthCheckConfig" AS logical
+ADD FIELD "failOnCritical" OF "HealthCheckConfig" AS logical 
   DESCRIPTION "Will critical state of probe fail overall health?"
   FORMAT "yes/no"
   INITIAL "no"
   MAX-WIDTH 1
   ORDER 140
 
-ADD FIELD "config" OF "HealthCheckConfig" AS clob
+ADD FIELD "config" OF "HealthCheckConfig" AS clob 
   DESCRIPTION "JSON-formatted configuration options for probe"
   FORMAT "x(8)"
   INITIAL ?
@@ -543,40 +543,40 @@ ADD FIELD "config" OF "HealthCheckConfig" AS clob
   CLOB-TYPE 2
   ORDER 150
 
-ADD FIELD "ServerUUID" OF "HealthCheckConfig" AS character
+ADD FIELD "ServerUUID" OF "HealthCheckConfig" AS character 
   FORMAT "x(16)"
   INITIAL ""
   MAX-WIDTH 32
   ORDER 10
 
-ADD INDEX "pukServerProbe" ON "HealthCheckConfig"
+ADD INDEX "pukServerProbe" ON "HealthCheckConfig" 
   AREA "Index Area"
   UNIQUE
   PRIMARY
-  INDEX-FIELD "ServerUUID" ASCENDING
-  INDEX-FIELD "probeid" ASCENDING
-  INDEX-FIELD "parentid" ASCENDING
-  INDEX-FIELD "config_name" ASCENDING
-  INDEX-FIELD "timestamp" ASCENDING
+  INDEX-FIELD "ServerUUID" ASCENDING 
+  INDEX-FIELD "probeid" ASCENDING 
+  INDEX-FIELD "parentid" ASCENDING 
+  INDEX-FIELD "config_name" ASCENDING 
+  INDEX-FIELD "timestamp" ASCENDING 
 
-ADD INDEX "idxParentProbe" ON "HealthCheckConfig"
+ADD INDEX "idxParentProbe" ON "HealthCheckConfig" 
   AREA "Index Area"
-  INDEX-FIELD "ServerUUID" ASCENDING
-  INDEX-FIELD "parentid" ASCENDING
+  INDEX-FIELD "ServerUUID" ASCENDING 
+  INDEX-FIELD "parentid" ASCENDING 
 
 ADD TABLE "HealthCheckData"
   AREA "Data Area"
   DESCRIPTION "HealthCheck Data Points"
   DUMP-NAME "healthdata"
 
-ADD FIELD "probeid" OF "HealthCheckData" AS integer
+ADD FIELD "probeid" OF "HealthCheckData" AS integer 
   DESCRIPTION "Probe Identifier"
   FORMAT ">>9"
   INITIAL "0"
   MAX-WIDTH 4
   ORDER 20
 
-ADD FIELD "health" OF "HealthCheckData" AS decimal
+ADD FIELD "health" OF "HealthCheckData" AS decimal 
   DESCRIPTION "Probe Health (0-1)"
   FORMAT ">>9.9"
   INITIAL "0"
@@ -584,35 +584,35 @@ ADD FIELD "health" OF "HealthCheckData" AS decimal
   DECIMALS 1
   ORDER 30
 
-ADD FIELD "ignore" OF "HealthCheckData" AS logical
+ADD FIELD "ignore" OF "HealthCheckData" AS logical 
   DESCRIPTION "Is probe currently ignored?"
   FORMAT "yes/no"
   INITIAL "no"
   MAX-WIDTH 1
   ORDER 60
 
-ADD FIELD "failOnCritical" OF "HealthCheckData" AS logical
+ADD FIELD "failOnCritical" OF "HealthCheckData" AS logical 
   DESCRIPTION "Will critical state of probe fail overall health?"
   FORMAT "yes/no"
   INITIAL "no"
   MAX-WIDTH 1
   ORDER 70
 
-ADD FIELD "failedBy" OF "HealthCheckData" AS character
+ADD FIELD "failedBy" OF "HealthCheckData" AS character 
   DESCRIPTION "Item responsible for failure of probe"
   FORMAT "x(64)"
   INITIAL ""
   MAX-WIDTH 128
   ORDER 80
 
-ADD FIELD "lastpoll" OF "HealthCheckData" AS datetime-tz
+ADD FIELD "lastpoll" OF "HealthCheckData" AS datetime-tz 
   DESCRIPTION "Date/time of Last Poll"
   FORMAT "99/99/9999 HH:MM:SS.SSS+HH:MM"
   INITIAL ?
   MAX-WIDTH 12
   ORDER 100
 
-ADD FIELD "data_value" OF "HealthCheckData" AS clob
+ADD FIELD "data_value" OF "HealthCheckData" AS clob 
   DESCRIPTION "JSON-formatted raw data for probe"
   FORMAT "x(8)"
   INITIAL ?
@@ -624,57 +624,57 @@ ADD FIELD "data_value" OF "HealthCheckData" AS clob
   CLOB-TYPE 2
   ORDER 90
 
-ADD FIELD "marginal" OF "HealthCheckData" AS logical
+ADD FIELD "marginal" OF "HealthCheckData" AS logical 
   DESCRIPTION "Has probe exceeded marginal value?"
   FORMAT "yes/no"
   INITIAL "no"
   MAX-WIDTH 1
   ORDER 40
 
-ADD FIELD "critical" OF "HealthCheckData" AS logical
+ADD FIELD "critical" OF "HealthCheckData" AS logical 
   DESCRIPTION "Has probe exceeded critical value?"
   FORMAT "yes/no"
   INITIAL "no"
   MAX-WIDTH 1
   ORDER 50
 
-ADD FIELD "ServerUUID" OF "HealthCheckData" AS character
+ADD FIELD "ServerUUID" OF "HealthCheckData" AS character 
   FORMAT "x(16)"
   INITIAL ""
   MAX-WIDTH 32
   ORDER 10
 
-ADD INDEX "pukServerProbe" ON "HealthCheckData"
+ADD INDEX "pukServerProbe" ON "HealthCheckData" 
   AREA "Index Area"
   UNIQUE
   PRIMARY
-  INDEX-FIELD "ServerUUID" ASCENDING
-  INDEX-FIELD "probeid" ASCENDING
-  INDEX-FIELD "lastpoll" ASCENDING
+  INDEX-FIELD "ServerUUID" ASCENDING 
+  INDEX-FIELD "probeid" ASCENDING 
+  INDEX-FIELD "lastpoll" ASCENDING 
 
 ADD TABLE "ProfilerData"
   AREA "Data Area"
   DUMP-NAME "profile"
 
-ADD FIELD "Timestamp" OF "ProfilerData" AS datetime
+ADD FIELD "Timestamp" OF "ProfilerData" AS datetime 
   FORMAT "99/99/9999 HH:MM:SS.SSS"
   INITIAL ?
   MAX-WIDTH 8
   ORDER 20
 
-ADD FIELD "SessionUUID" OF "ProfilerData" AS character
+ADD FIELD "SessionUUID" OF "ProfilerData" AS character 
   FORMAT "x(16)"
   INITIAL ""
   MAX-WIDTH 16
   ORDER 10
 
-ADD FIELD "ProfileBytes" OF "ProfilerData" AS int64
+ADD FIELD "ProfileBytes" OF "ProfilerData" AS int64 
   FORMAT ">>>,>>>,>>>,>>9"
   INITIAL "0"
   MAX-WIDTH 4
   ORDER 30
 
-ADD FIELD "CodeProfile" OF "ProfilerData" AS clob
+ADD FIELD "CodeProfile" OF "ProfilerData" AS clob 
   FORMAT "x(8)"
   INITIAL ?
   LOB-AREA "LOB Area"
@@ -685,300 +685,318 @@ ADD FIELD "CodeProfile" OF "ProfilerData" AS clob
   CLOB-TYPE 2
   ORDER 40
 
-ADD FIELD "RequestLength" OF "ProfilerData" AS int64
+ADD FIELD "RequestLength" OF "ProfilerData" AS int64 
   FORMAT ">>>,>>>,>>>,>>9"
   INITIAL "0"
   MAX-WIDTH 8
   ORDER 50
 
-ADD FIELD "APIEntryPoint" OF "ProfilerData" AS character
+ADD FIELD "APIEntryPoint" OF "ProfilerData" AS character 
   DESCRIPTION "Originating procedure or method for this profiler request."
   FORMAT "x(32)"
   INITIAL ""
   MAX-WIDTH 64
   ORDER 60
 
-ADD FIELD "TestRun" OF "ProfilerData" AS character
+ADD FIELD "TestRun" OF "ProfilerData" AS character 
   DESCRIPTION "User-friendly name for a test which may have generated this data; set via PROFILER:DESCRIPTION."
   FORMAT "x(32)"
   INITIAL ""
   MAX-WIDTH 64
   ORDER 70
 
-ADD FIELD "Transport" OF "ProfilerData" AS character
+ADD FIELD "Transport" OF "ProfilerData" AS character 
   DESCRIPTION "Transport used for the request (REST, WEB, APSV, SOAP)"
   FORMAT "x(4)"
   INITIAL ""
   MAX-WIDTH 8
   ORDER 80
 
-ADD INDEX "pukMain" ON "ProfilerData"
+ADD INDEX "pukMain" ON "ProfilerData" 
   AREA "Index Area"
   UNIQUE
   PRIMARY
-  INDEX-FIELD "SessionUUID" ASCENDING
-  INDEX-FIELD "Timestamp" ASCENDING
+  INDEX-FIELD "SessionUUID" ASCENDING 
+  INDEX-FIELD "Timestamp" ASCENDING 
 
 ADD TABLE "RequestInfo"
   AREA "Data Area"
   DUMP-NAME "request"
 
-ADD FIELD "ServerUUID" OF "RequestInfo" AS character
+ADD FIELD "ServerUUID" OF "RequestInfo" AS character 
   FORMAT "x(16)"
   INITIAL ""
   MAX-WIDTH 32
   ORDER 10
 
-ADD FIELD "SessionUUID" OF "RequestInfo" AS character
+ADD FIELD "SessionUUID" OF "RequestInfo" AS character 
   FORMAT "x(16)"
   INITIAL ""
   MAX-WIDTH 32
   ORDER 20
 
-ADD FIELD "RequestUUID" OF "RequestInfo" AS character
+ADD FIELD "RequestUUID" OF "RequestInfo" AS character 
   FORMAT "x(32)"
   INITIAL ""
   MAX-WIDTH 64
   ORDER 40
 
-ADD FIELD "RequestNum" OF "RequestInfo" AS int64
+ADD FIELD "RequestNum" OF "RequestInfo" AS int64 
   FORMAT ">>>,>>>,>>>,>>>,>>9"
   INITIAL "0"
   MAX-WIDTH 4
   ORDER 50
 
-ADD FIELD "ClientID" OF "RequestInfo" AS character
+ADD FIELD "ClientID" OF "RequestInfo" AS character 
   FORMAT "x(30)"
   INITIAL ""
   MAX-WIDTH 60
   ORDER 60
 
-ADD FIELD "ConnectionID" OF "RequestInfo" AS integer
+ADD FIELD "ConnectionID" OF "RequestInfo" AS integer 
   FORMAT ">>>>>9"
   INITIAL "0"
   MAX-WIDTH 4
   ORDER 70
 
-ADD FIELD "ProcName" OF "RequestInfo" AS character
+ADD FIELD "ProcName" OF "RequestInfo" AS character 
   FORMAT "x(100)"
   INITIAL ""
   MAX-WIDTH 200
   ORDER 80
 
-ADD FIELD "StartTime" OF "RequestInfo" AS datetime
+ADD FIELD "StartTime" OF "RequestInfo" AS datetime 
   FORMAT "99/99/9999 HH:MM:SS.SSS"
   INITIAL ?
   MAX-WIDTH 8
   ORDER 90
 
-ADD FIELD "EndTime" OF "RequestInfo" AS datetime
+ADD FIELD "EndTime" OF "RequestInfo" AS datetime 
   FORMAT "99/99/9999 HH:MM:SS.SSS"
   INITIAL ?
   MAX-WIDTH 8
   ORDER 100
 
-ADD FIELD "Elapsed" OF "RequestInfo" AS int64
+ADD FIELD "Elapsed" OF "RequestInfo" AS int64 
   FORMAT ">>>,>>>,>>>,>>9"
   INITIAL "0"
   MAX-WIDTH 4
   ORDER 110
 
-ADD FIELD "WebAppName" OF "RequestInfo" AS character
+ADD FIELD "WebAppName" OF "RequestInfo" AS character 
   FORMAT "x(20)"
   INITIAL ""
   MAX-WIDTH 40
   ORDER 120
 
-ADD FIELD "Transport" OF "RequestInfo" AS character
+ADD FIELD "Transport" OF "RequestInfo" AS character 
   FORMAT "x(10)"
   INITIAL ""
   MAX-WIDTH 20
   ORDER 130
 
-ADD FIELD "RequestID" OF "RequestInfo" AS character
+ADD FIELD "RequestID" OF "RequestInfo" AS character 
   FORMAT "x(10)"
   INITIAL ""
   MAX-WIDTH 20
   ORDER 140
 
-ADD FIELD "SampleUUID" OF "RequestInfo" AS character
+ADD FIELD "SampleUUID" OF "RequestInfo" AS character 
   FORMAT "x(16)"
   INITIAL ""
   MAX-WIDTH 32
   ORDER 30
 
-ADD INDEX "pukMain" ON "RequestInfo"
+ADD INDEX "pukMain" ON "RequestInfo" 
   AREA "Index Area"
   UNIQUE
   PRIMARY
-  INDEX-FIELD "ServerUUID" ASCENDING
-  INDEX-FIELD "SessionUUID" ASCENDING
-  INDEX-FIELD "RequestNum" ASCENDING
+  INDEX-FIELD "ServerUUID" ASCENDING 
+  INDEX-FIELD "SessionUUID" ASCENDING 
+  INDEX-FIELD "RequestNum" ASCENDING 
 
-ADD INDEX "idxStart" ON "RequestInfo"
+ADD INDEX "idxEnd" ON "RequestInfo" 
   AREA "Index Area"
-  INDEX-FIELD "SampleUUID" ASCENDING
-  INDEX-FIELD "StartTime" ASCENDING
+  INDEX-FIELD "SampleUUID" ASCENDING 
+  INDEX-FIELD "EndTime" ASCENDING 
+
+ADD INDEX "idxRequest" ON "RequestInfo" 
+  AREA "Index Area"
+  INDEX-FIELD "RequestUUID" ASCENDING 
+
+ADD INDEX "idxSession" ON "RequestInfo" 
+  AREA "Index Area"
+  INDEX-FIELD "SessionUUID" ASCENDING 
+
+ADD INDEX "idxStart" ON "RequestInfo" 
+  AREA "Index Area"
+  INDEX-FIELD "SampleUUID" ASCENDING 
+  INDEX-FIELD "StartTime" ASCENDING 
 
 ADD TABLE "ServerInfo"
   AREA "Data Area"
   DUMP-NAME "server"
 
-ADD FIELD "ApplicationName" OF "ServerInfo" AS character
+ADD FIELD "ApplicationName" OF "ServerInfo" AS character 
   FORMAT "x(20)"
   INITIAL ""
   MAX-WIDTH 16
   ORDER 10
 
-ADD FIELD "ServerName" OF "ServerInfo" AS character
+ADD FIELD "ServerName" OF "ServerInfo" AS character 
   FORMAT "x(20)"
   INITIAL ""
   MAX-WIDTH 16
   ORDER 20
 
-ADD FIELD "ServerUUID" OF "ServerInfo" AS character
+ADD FIELD "ServerUUID" OF "ServerInfo" AS character 
   FORMAT "x(16)"
   INITIAL ""
   MAX-WIDTH 16
   ORDER 30
 
-ADD INDEX "pukMain" ON "ServerInfo"
+ADD INDEX "pukMain" ON "ServerInfo" 
   AREA "Index Area"
   UNIQUE
   PRIMARY
-  INDEX-FIELD "ApplicationName" ASCENDING
-  INDEX-FIELD "ServerName" ASCENDING
+  INDEX-FIELD "ApplicationName" ASCENDING 
+  INDEX-FIELD "ServerName" ASCENDING 
 
-ADD INDEX "ukUUID" ON "ServerInfo"
+ADD INDEX "ukUUID" ON "ServerInfo" 
   AREA "Index Area"
   UNIQUE
-  INDEX-FIELD "ServerUUID" ASCENDING
+  INDEX-FIELD "ServerUUID" ASCENDING 
 
 ADD TABLE "SessionInfo"
   AREA "Data Area"
   DUMP-NAME "sessioninfo"
 
-ADD FIELD "ServerUUID" OF "SessionInfo" AS character
+ADD FIELD "ServerUUID" OF "SessionInfo" AS character 
   FORMAT "x(16)"
   INITIAL ""
   MAX-WIDTH 16
   ORDER 10
 
-ADD FIELD "AgentPID" OF "SessionInfo" AS integer
+ADD FIELD "AgentPID" OF "SessionInfo" AS integer 
   FORMAT ">>>>>>>>9"
   INITIAL "0"
   MAX-WIDTH 4
   ORDER 20
 
-ADD FIELD "SessionID" OF "SessionInfo" AS integer
+ADD FIELD "SessionID" OF "SessionInfo" AS integer 
   FORMAT ">>>,>>>,>>9"
   INITIAL "0"
   MAX-WIDTH 4
   ORDER 30
 
-ADD FIELD "Started" OF "SessionInfo" AS datetime
+ADD FIELD "Started" OF "SessionInfo" AS datetime 
   DESCRIPTION "Timestamp of when this session was started, or when it was first seen in reported metrics."
   FORMAT "99/99/9999 HH:MM:SS.SSS"
   INITIAL ?
   MAX-WIDTH 8
   ORDER 40
 
-ADD FIELD "SessionUUID" OF "SessionInfo" AS character
+ADD FIELD "SessionUUID" OF "SessionInfo" AS character 
   FORMAT "x(16)"
   INITIAL ""
   MAX-WIDTH 32
   ORDER 50
 
-ADD INDEX "pukMain" ON "SessionInfo"
+ADD INDEX "pukMain" ON "SessionInfo" 
   AREA "Index Area"
   UNIQUE
   PRIMARY
-  INDEX-FIELD "ServerUUID" ASCENDING
-  INDEX-FIELD "AgentPID" ASCENDING
-  INDEX-FIELD "SessionID" ASCENDING
+  INDEX-FIELD "ServerUUID" ASCENDING 
+  INDEX-FIELD "AgentPID" ASCENDING 
+  INDEX-FIELD "SessionID" ASCENDING 
 
-ADD INDEX "ukUUID" ON "SessionInfo"
+ADD INDEX "idxStarted" ON "SessionInfo" 
+  AREA "Index Area"
+  INDEX-FIELD "ServerUUID" ASCENDING 
+  INDEX-FIELD "Started" ASCENDING 
+  INDEX-FIELD "AgentPID" ASCENDING 
+  INDEX-FIELD "SessionID" ASCENDING 
+
+ADD INDEX "ukUUID" ON "SessionInfo" 
   AREA "Index Area"
   UNIQUE
-  INDEX-FIELD "SessionUUID" ASCENDING
+  INDEX-FIELD "SessionUUID" ASCENDING 
 
 ADD TABLE "SessionSample"
   AREA "Data Area"
   DUMP-NAME "sessionsample"
 
-ADD FIELD "SessionUUID" OF "SessionSample" AS character
+ADD FIELD "SessionUUID" OF "SessionSample" AS character 
   FORMAT "x(16)"
   INITIAL ""
   MAX-WIDTH 32
   ORDER 10
 
-ADD FIELD "SampleUUID" OF "SessionSample" AS character
+ADD FIELD "SampleUUID" OF "SessionSample" AS character 
   FORMAT "x(16)"
   INITIAL ""
   MAX-WIDTH 32
   ORDER 20
 
-ADD FIELD "Timestamp" OF "SessionSample" AS datetime
+ADD FIELD "Timestamp" OF "SessionSample" AS datetime 
   FORMAT "99/99/9999 HH:MM:SS.SSS"
   INITIAL ?
   MAX-WIDTH 8
   ORDER 40
 
-ADD FIELD "MemoryBytes" OF "SessionSample" AS int64
+ADD FIELD "MemoryBytes" OF "SessionSample" AS int64 
   DESCRIPTION "Total memory reported by the session at the time of this sample"
   FORMAT ">>>,>>>,>>>,>>>,>>9"
   INITIAL "0"
   MAX-WIDTH 4
   ORDER 50
 
-ADD FIELD "ObjectCount" OF "SessionSample" AS integer
+ADD FIELD "ObjectCount" OF "SessionSample" AS integer 
   DESCRIPTION "Roll-up value of total ABLObjects encountered at the time of this sample."
   FORMAT ">>>,>>>,>>9"
   INITIAL "0"
   MAX-WIDTH 4
   ORDER 60
 
-ADD FIELD "SampleGroup" OF "SessionSample" AS character
+ADD FIELD "SampleGroup" OF "SessionSample" AS character 
   FORMAT "x(20)"
   INITIAL ""
   MAX-WIDTH 40
   HELP "User-defined name for current sample grouping."
   ORDER 30
 
-ADD FIELD "RequestCount" OF "SessionSample" AS int64
+ADD FIELD "RequestCount" OF "SessionSample" AS int64 
   DESCRIPTION "Roll-up value of total requests served by this session since last sample"
   FORMAT ">>>,>>>,>>>,>>9"
   INITIAL "0"
   MAX-WIDTH 8
   ORDER 70
 
-ADD INDEX "pukMain" ON "SessionSample"
+ADD INDEX "pukMain" ON "SessionSample" 
   AREA "Index Area"
   UNIQUE
   PRIMARY
-  INDEX-FIELD "SessionUUID" ASCENDING
-  INDEX-FIELD "SampleUUID" ASCENDING
-  INDEX-FIELD "Timestamp" ASCENDING
+  INDEX-FIELD "SessionUUID" ASCENDING 
+  INDEX-FIELD "SampleUUID" ASCENDING 
+  INDEX-FIELD "Timestamp" ASCENDING 
 
-ADD INDEX "idxName" ON "SessionSample"
+ADD INDEX "idxName" ON "SessionSample" 
   AREA "Index Area"
-  INDEX-FIELD "SessionUUID" ASCENDING
-  INDEX-FIELD "SampleGroup" ASCENDING
+  INDEX-FIELD "SessionUUID" ASCENDING 
+  INDEX-FIELD "SampleGroup" ASCENDING 
 
-ADD INDEX "idxSessionTime" ON "SessionSample"
+ADD INDEX "idxSessionTime" ON "SessionSample" 
   AREA "Index Area"
-  INDEX-FIELD "SessionUUID" ASCENDING
-  INDEX-FIELD "MemoryBytes" ASCENDING
-  INDEX-FIELD "ObjectCount" ASCENDING
-  INDEX-FIELD "Timestamp" ASCENDING
+  INDEX-FIELD "SessionUUID" ASCENDING 
+  INDEX-FIELD "Timestamp" ASCENDING 
 
-ADD INDEX "ukUUID" ON "SessionSample"
+ADD INDEX "ukUUID" ON "SessionSample" 
   AREA "Index Area"
   UNIQUE
-  INDEX-FIELD "SampleUUID" ASCENDING
+  INDEX-FIELD "SampleUUID" ASCENDING 
 
 .
 PSC
 cpstream=UTF-8
 .
-0000021021
+0000022256


### PR DESCRIPTION
This addresses a situation where tracking a large number of sessions for an MSAgent over 1 or more full days results in a significant amount of data. This data causes a severe slowdown in the UI due to the fetching and display of data collected. The changes here add a date selector field along with a time period selector--this allows limiting results to a single day, and over the last 2, 4, 6, etc. hours of the day. This should allow a faster means of viewing the most recent server metrics while still allowing access to historic data.